### PR TITLE
RSP-1205: Add penalty group payment endpoint and call CPMS card payment orchestration

### DIFF
--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -38,12 +38,15 @@ const redirectForSinglePenalty = (req, res, penaltyDetails) => {
 
 const redirectForPenaltyGroup = (req, res, penaltyGroupDetails, penaltyGroupType) => {
   const redirectUrl = `https://${req.get('host')}${config.urlRoot}/payment-code/${penaltyGroupDetails.paymentCode}/confirmPayment`;
+  const penaltyOverviewsForType = penaltyGroupDetails.penaltyDetails
+    .find(grouping => grouping.type === penaltyGroupType).penalties;
+  const amountForType = penaltyOverviewsForType.reduce((total, pen) => total + pen.amount, 0);
 
   return cpmsService.createGroupCardPaymentTransaction(
-    penaltyGroupDetails.penaltyGroupDetails.amount,
+    amountForType,
     penaltyGroupDetails.penaltyGroupDetails.registrationNumber,
     penaltyGroupType,
-    penaltyGroupDetails.penaltyDetails,
+    penaltyOverviewsForType,
     redirectUrl,
   ).then(response => res.redirect(response.data.gateway_url))
     .catch((error) => {

--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -3,41 +3,70 @@ import PenaltyService from './../services/penalty.service';
 import CpmsService from './../services/cpms.service';
 import config from './../config';
 import logger from './../utils/logger';
+import PenaltyGroupService from '../services/penaltyGroup.service';
 
 const paymentService = new PaymentService(config.paymentServiceUrl);
 const penaltyService = new PenaltyService(config.penaltyServiceUrl);
+const penaltyGroupService = new PenaltyGroupService(config.penaltyServiceUrl);
 const cpmsService = new CpmsService(config.cpmsServiceUrl);
 
-const getPenaltyDetails = (req) => {
-  if (req.params.payment_code) {
-    return penaltyService.getByPaymentCode(req.params.payment_code);
+const getPenaltyOrGroupDetails = (req) => {
+  const paymentCode = req.params.payment_code;
+  if (paymentCode) {
+    return paymentCode.length === 16 ?
+      penaltyService.getByPaymentCode(paymentCode)
+      : penaltyGroupService.getByPenaltyGroupPaymentCode(paymentCode);
   }
   return penaltyService.getById(req.params.penalty_id);
 };
 
+const redirectForSinglePenalty = (req, res, penaltyDetails) => {
+  const redirectUrl = `https://${req.get('host')}${config.urlRoot}/payment-code/${penaltyDetails.paymentCode}/confirmPayment`;
+
+  return cpmsService.createCardPaymentTransaction(
+    penaltyDetails.vehicleReg,
+    penaltyDetails.reference,
+    penaltyDetails.type,
+    penaltyDetails.amount,
+    redirectUrl,
+  ).then(response => res.redirect(response.data.gateway_url))
+    .catch((error) => {
+      logger.error(error);
+      res.redirect(`${config.urlRoot}/payment-code/${penaltyDetails.paymentCode}`);
+    });
+};
+
+const redirectForPenaltyGroup = (req, res, penaltyGroupDetails, penaltyGroupType) => {
+  const redirectUrl = `https://${req.get('host')}${config.urlRoot}/payment-code/${penaltyGroupDetails.paymentCode}/confirmPayment`;
+  return cpmsService.createCardPaymentTransaction(
+    penaltyGroupDetails.penaltyGroupDetails.registrationNumber,
+    penaltyGroupDetails.paymentCode,
+    penaltyGroupType,
+    penaltyGroupDetails.penaltyGroupDetails.amount,
+    redirectUrl,
+  ).then(response => res.redirect(response.data.gateway_url))
+    .catch((error) => {
+      logger.error(error);
+      res.redirect(`${config.urlRoot}/payment-code/${penaltyGroupDetails.paymentCode}`);
+    });
+};
+
 export const redirectToPaymentPage = async (req, res) => {
   let penaltyDetails;
-
   try {
-    penaltyDetails = await getPenaltyDetails(req);
+    penaltyDetails = await getPenaltyOrGroupDetails(req);
 
-    if (penaltyDetails.status === 'PAID') {
-      return res.redirect(`${config.urlRoot}/payment-code/${penaltyDetails.paymentCode}`);
+    if (penaltyDetails.status === 'PAID' || penaltyDetails.paymentStatus === 'PAID') {
+      const url = `${config.urlRoot}/payment-code/${penaltyDetails.paymentCode}`;
+      return res.redirect(url);
     }
 
-    const redirectUrl = `https://${req.get('host')}${config.urlRoot}/payment-code/${penaltyDetails.paymentCode}/confirmPayment`;
+    if (penaltyDetails.isPenaltyGroup) {
+      const penaltyGroupType = req.params.type;
+      return redirectForPenaltyGroup(req, res, penaltyDetails, penaltyGroupType);
+    }
 
-    return cpmsService.createCardPaymentTransaction(
-      penaltyDetails.vehicleReg,
-      penaltyDetails.reference,
-      penaltyDetails.type,
-      penaltyDetails.amount,
-      redirectUrl,
-    ).then(response => res.redirect(response.data.gateway_url))
-      .catch((error) => {
-        logger.error(error);
-        res.redirect(`${config.urlRoot}/payment-code/${penaltyDetails.paymentCode}`);
-      });
+    return redirectForSinglePenalty(req, res, penaltyDetails);
   } catch (error) {
     logger.error(error);
     return res.redirect(`${config.urlRoot}/?invalidPaymentCode`);
@@ -49,7 +78,7 @@ export const confirmPayment = async (req, res) => {
   let penaltyDetails;
 
   try {
-    penaltyDetails = await getPenaltyDetails(req);
+    penaltyDetails = await getPenaltyOrGroupDetails(req);
     cpmsService.confirmPayment(receiptReference, penaltyDetails.type).then((response) => {
       if (response.data.code === 801) {
         // Payment successful

--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -38,6 +38,7 @@ const redirectForSinglePenalty = (req, res, penaltyDetails) => {
 
 const redirectForPenaltyGroup = (req, res, penaltyGroupDetails, penaltyGroupType) => {
   const redirectUrl = `https://${req.get('host')}${config.urlRoot}/payment-code/${penaltyGroupDetails.paymentCode}/confirmPayment`;
+
   return cpmsService.createGroupCardPaymentTransaction(
     penaltyGroupDetails.penaltyGroupDetails.amount,
     penaltyGroupDetails.penaltyGroupDetails.registrationNumber,

--- a/src/server/routes.js
+++ b/src/server/routes.js
@@ -17,6 +17,7 @@ router.post('/payment-code', paymentCodeController.validatePaymentCode);
 router.get('/payment-code/:payment_code', paymentCodeController.getPaymentDetails);
 router.post('/payment-code/:payment_code/:type/details', paymentCodeController.getMultiPenaltyPaymentSummary);
 router.post('/payment-code/:payment_code/payment', paymentController.redirectToPaymentPage);
+router.post('/payment-code/:payment_code/:type/payment', paymentController.redirectToPaymentPage);
 router.get('/payment-code/:payment_code/confirmPayment', paymentController.confirmPayment);
 
 export default router;

--- a/src/server/services/cpms.service.js
+++ b/src/server/services/cpms.service.js
@@ -15,6 +15,10 @@ export default class PaymentService {
     }));
   }
 
+  createGroupCardPaymentTransaction(amount, vehicleReg, penaltyType, penaltyDetails, redirectUrl) {
+    return null;
+  }
+
   confirmPayment(receiptReference, penaltyType) {
     return this.httpClient.post('confirm/', JSON.stringify({
       receipt_reference: receiptReference,

--- a/src/server/services/cpms.service.js
+++ b/src/server/services/cpms.service.js
@@ -15,8 +15,22 @@ export default class PaymentService {
     }));
   }
 
-  createGroupCardPaymentTransaction(amount, vehicleReg, penaltyType, penaltyDetails, redirectUrl) {
-    return null;
+  createGroupCardPaymentTransaction(amount, vehicleReg, type, penaltyOverviews, redirectUrl) {
+    return this.httpClient.post('groupCardPayment/', {
+      TotalAmount: amount,
+      VehicleRegistration: vehicleReg,
+      PenaltyType: type,
+      RedirectUrl: redirectUrl,
+      Penalties: penaltyOverviews.map(PaymentService.sanitisePenaltyForCpmsGroupCall),
+    });
+  }
+
+  static sanitisePenaltyForCpmsGroupCall(penalty) {
+    return {
+      PenaltyReference: penalty.reference,
+      PenaltyAmount: penalty.amount,
+      VehicleRegistration: penalty.vehicleReg,
+    };
   }
 
   confirmPayment(receiptReference, penaltyType) {

--- a/test/controllers/payment.controller.spec.js
+++ b/test/controllers/payment.controller.spec.js
@@ -93,6 +93,23 @@ describe('Payment Controller', () => {
             penalties: [
               {
                 vehicleRegistration: '11ABC',
+                amount: 100,
+                type: 'FPN',
+              },
+              {
+                vehicleRegistration: '11ABC',
+                amount: 50,
+                type: 'FPN',
+              },
+            ],
+          },
+          {
+            type: 'IM',
+            penalties: [
+              {
+                vehicleRegistration: '11ABC',
+                amount: 80,
+                type: 'IM',
               },
             ],
           },
@@ -114,7 +131,7 @@ describe('Payment Controller', () => {
             nextPayment: null,
           });
         mockCpmsSvcGroup
-          .withArgs(230, '11ABC', 'FPN', fakePenaltyDetails, 'https://localhost/payment-code/46uu8efys1o/confirmPayment')
+          .withArgs(150, '11ABC', 'FPN', fakePenaltyDetails[0].penalties, 'https://localhost/payment-code/46uu8efys1o/confirmPayment')
           .resolves({ data: { gateway_url: 'http://cpms.gateway' } });
 
         await PaymentController.redirectToPaymentPage(requestForPaymentCode('46uu8efys1o'), responseHandle);

--- a/test/controllers/payment.controller.spec.js
+++ b/test/controllers/payment.controller.spec.js
@@ -1,0 +1,112 @@
+import { describe, it, after, afterEach, before } from 'mocha';
+import sinon from 'sinon';
+
+import * as PaymentController from '../../src/server/controllers/payment.controller';
+import PenaltyService from '../../src/server/services/penalty.service';
+import PenaltyGroupService from '../../src/server/services/penaltyGroup.service';
+import CpmsService from '../../src/server/services/cpms.service';
+
+function requestForPaymentCode(paymentCode) {
+  return {
+    params: {
+      payment_code: paymentCode,
+      type: 'FPN',
+    },
+    get: (key) => {
+      const gettables = {
+        host: 'localhost',
+      };
+      return gettables[key];
+    },
+  };
+}
+
+describe('Payment Controller', () => {
+  describe('redirects to payment page for penalty groups', () => {
+    let mockPenaltySvc;
+    let mockPenaltyGroupSvc;
+    let mockCpmsSvc;
+    let redirectSpy;
+    let responseHandle;
+
+    before(() => {
+      mockPenaltySvc = sinon.stub(PenaltyService.prototype, 'getByPaymentCode');
+      mockPenaltyGroupSvc = sinon.stub(PenaltyGroupService.prototype, 'getByPenaltyGroupPaymentCode');
+      mockCpmsSvc = sinon.stub(CpmsService.prototype, 'createCardPaymentTransaction');
+      redirectSpy = sinon.spy({ redirect: () => {} }, 'redirect');
+      responseHandle = { redirect: redirectSpy };
+    });
+
+    afterEach(() => {
+      mockPenaltySvc.reset();
+      mockPenaltyGroupSvc.reset();
+      mockCpmsSvc.reset();
+      redirectSpy.reset();
+    });
+
+    after(() => {
+      PenaltyService.prototype.getByPaymentCode.restore();
+      PenaltyGroupService.prototype.getByPenaltyGroupPaymentCode.restore();
+      CpmsService.prototype.createCardPaymentTransaction.restore();
+    });
+
+    describe('for single penalty payment codes', () => {
+      it('should redirect to the payment code URL when status is paid', async () => {
+        mockPenaltySvc.withArgs('1111111111111111')
+          .resolves({ status: 'PAID', paymentCode: '1111111111111111' });
+
+        await PaymentController.redirectToPaymentPage({ params: { payment_code: '1111111111111111' } }, responseHandle);
+
+        sinon.assert.calledWith(redirectSpy, '/payment-code/1111111111111111');
+      });
+
+      it('should redirect to the CPMS gateway URL returned when CPMS Service creates a transaction', async () => {
+        mockPenaltySvc
+          .withArgs('1111111111111111')
+          .resolves({
+            status: 'UNPAID',
+            paymentCode: '1111111111111111',
+            vehicleReg: '11ABC',
+            reference: '123',
+            type: 'FPN',
+            amount: 100,
+          });
+        mockCpmsSvc
+          .withArgs('11ABC', '123', 'FPN', 100, 'https://localhost/payment-code/1111111111111111/confirmPayment')
+          .resolves({ data: { gateway_url: 'http://cpms.gateway' } });
+
+        await PaymentController.redirectToPaymentPage(requestForPaymentCode('1111111111111111'), responseHandle);
+
+        sinon.assert.calledWith(redirectSpy, 'http://cpms.gateway');
+      });
+    });
+
+    describe('for multiple penalty payment codes', () => {
+      it('should redirect to the CPMS gateway URL returned when CPMS Service creates a transaction', async () => {
+        mockPenaltyGroupSvc
+          .withArgs('46uu8efys1o')
+          .resolves({
+            isPenaltyGroup: true,
+            penaltyGroupDetails: {
+              registrationNumber: '11ABC',
+              location: 'some location',
+              date: '01/01/1970',
+              amount: 230,
+              // splitAmounts,
+            },
+            paymentCode: '46uu8efys1o',
+            penaltyDetails: null,
+            paymentStatus: 'UNPAID',
+            nextPayment: {},
+          });
+        mockCpmsSvc
+          .withArgs('11ABC', '46uu8efys1o', 'FPN', 230, 'https://localhost/payment-code/46uu8efys1o/confirmPayment')
+          .resolves({ data: { gateway_url: 'http://cpms.gateway' } });
+
+        await PaymentController.redirectToPaymentPage(requestForPaymentCode('46uu8efys1o'), responseHandle);
+
+        sinon.assert.calledWith(redirectSpy, 'http://cpms.gateway');
+      });
+    });
+  });
+});

--- a/test/data/penaltyGroups.js
+++ b/test/data/penaltyGroups.js
@@ -1,0 +1,41 @@
+export default [
+  {
+    ID: 'f31r82ismx',
+    PaymentStatus: '<UNPAID|PAID>',
+    VehicleRegistration: 'AB 123 CD',
+    Timestamp: '<unix timestamp>',
+    Location: '<Long description of location>',
+    Payments: [
+      {
+        PaymentCategory: 'FPN',
+        TotalAmount: 100,
+        PaymentStatus: '<UNPAID|PAID>',
+        Penalties: [
+          {
+            Enabled: true,
+            Origin: 'APP',
+            ID: '1245853256893_FPN',
+            Offset: 1519724746.142,
+            Value: {
+              paymentToken: 'fd7c1abd93c4c074',
+              dateTime: 1519689600,
+              siteCode: 1,
+              vehicleDetails: {
+                regNo: 'AA',
+              },
+              referenceNo: '1245853256893',
+              nonEndorsableOffence: [],
+              penaltyType: 'FPN',
+              placeWhereIssued: 'Abingdon (A34/41 interchange - South of Oxford)',
+              officerName: 'dvsa.officerfpns@bjss.com',
+              penaltyAmount: 100,
+              officerID: 'Z7F6yxnw--6DJf4sLsxjg_S-3Gvrl5MxV-1iY7RRNiA',
+              paymentStatus: 'UNPAID',
+            },
+            Hash: 'b9db158e491451adf1fd8c9a3b1cfba5212b6fa84e1079f585e0a90a4b823af1',
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/test/services/cpms.service.spec.js
+++ b/test/services/cpms.service.spec.js
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+import { after, afterEach, beforeEach, describe, it } from 'mocha';
+import sinon from 'sinon';
+import CpmsService from '../../src/server/services/cpms.service';
+import SignedHttpClient from '../../src/server/utils/httpclient';
+
+describe('Payment Service', () => {
+  describe('groupCardPaymentTransaction', () => {
+    let mockHttpClient;
+    let cpmsService;
+
+    beforeEach(() => {
+      mockHttpClient = sinon.stub(SignedHttpClient.prototype, 'post');
+      cpmsService = new CpmsService('testurl');
+    });
+
+    afterEach(() => {
+      mockHttpClient.resetHistory();
+    });
+
+    after(() => {
+      SignedHttpClient.prototype.post.restore();
+    });
+
+    it('returns a promise from POSTing payment details to the cardPaymentGroup endpoint', () => {
+      const httpPromise = Promise.resolve('resp');
+      mockHttpClient
+        .returns(httpPromise);
+
+      const penaltyOverviews = [
+        {
+          complete: true,
+          reference: '820500000901',
+          paymentCode: '1111111111111111',
+          issueDate: '11/10/2016',
+          vehicleReg: '11ABC',
+          formattedReference: '820500000901',
+          location: 'BLACKWALL TUNNEL A, PAVILLION WAY, METROPOLITAN',
+          amount: 100,
+          status: 'UNPAID',
+          type: 'FPN',
+          typeDescription: 'Fixed Penalty Notice',
+        },
+        {
+          complete: true,
+          reference: '820500000902',
+          paymentCode: '2222222222222222',
+          issueDate: '11/10/2016',
+          vehicleReg: '22XYZ',
+          formattedReference: '820500000902',
+          location: 'BLACKWALL TUNNEL A, PAVILLION WAY, METROPOLITAN',
+          amount: 50,
+          status: 'UNPAID',
+          type: 'FPN',
+          typeDescription: 'Fixed Penalty Notice',
+        },
+      ];
+
+      const returned = cpmsService.createGroupCardPaymentTransaction(150, '11ABC, 22XYZ', 'FPN', penaltyOverviews, 'http://redirect');
+
+      sinon.assert.calledWith(mockHttpClient, 'groupCardPayment/', {
+        TotalAmount: 150,
+        VehicleRegistration: '11ABC, 22XYZ',
+        PenaltyType: 'FPN',
+        RedirectUrl: 'http://redirect',
+        Penalties: [
+          {
+            PenaltyReference: '820500000901',
+            PenaltyAmount: 100,
+            VehicleRegistration: '11ABC',
+          },
+          {
+            PenaltyReference: '820500000902',
+            PenaltyAmount: 50,
+            VehicleRegistration: '22XYZ',
+          },
+        ],
+      });
+      expect(returned).to.be.equal(httpPromise);
+    });
+  });
+});

--- a/test/services/penalty.service.spec.js
+++ b/test/services/penalty.service.spec.js
@@ -6,13 +6,14 @@ import PenaltyService from '../../src/server/services/penalty.service';
 import SignedHttpClient from '../../src/server/utils/httpclient';
 import MockedBackendAPI from '../utils/mockedBackendAPI';
 import penalties from '../data/penalties';
+import penaltyGroups from '../data/penaltyGroups';
 
 use(chaiAsPromised);
 
 const httpClient = new SignedHttpClient('');
 
 describe('Penalty Service', () => {
-  const mockedBackendAPI = new MockedBackendAPI(penalties);
+  const mockedBackendAPI = new MockedBackendAPI(penalties, penaltyGroups);
 
   let mockedHttpClient;
   let penaltyService;
@@ -23,20 +24,22 @@ describe('Penalty Service', () => {
   });
 
   describe('Retrieves a penalty by payment code', () => {
-    it('Should retrieve the correct penalty [WHEN] a valid payment code is provided', async () => {
+    it('Should retrieve the correct penalty [WHEN] a valid single penalty payment code is provided', async () => {
       // Arrange
-      const validPaymentCode = '1111111111111111';
+      const singlePenaltyPaymentCode = '1111111111111111';
 
       mockedHttpClient = sinon.stub(httpClient, 'get').callsFake(code => mockedBackendAPI.getPenaltyByPaymentCode(code));
       penaltyService = new PenaltyService();
       penaltyService.httpClient = mockedHttpClient.rootObj;
 
       // Act
-      const result = await penaltyService.getByPaymentCode(validPaymentCode);
+      const result = await penaltyService.getByPaymentCode(singlePenaltyPaymentCode);
 
       // Assert
-      expect(result.paymentCode).to.equal(validPaymentCode);
+      expect(result.paymentCode).to.equal(singlePenaltyPaymentCode);
+      sinon.assert.calledWith(mockedHttpClient, 'documents/tokens/1111111111111111');
     });
+
     it('Should return a rejected promise [WHEN] an invalid payment code is provided', () => {
       // Arrange
       const invalidPaymentCode = 'zzxzxzxasdqawsdaszxcwqesd$"£%$£$"%';

--- a/test/services/penaltyGroup.service.spec.js
+++ b/test/services/penaltyGroup.service.spec.js
@@ -1,0 +1,57 @@
+import { describe, it, afterEach } from 'mocha';
+import sinon from 'sinon';
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import PenaltyGroupService from '../../src/server/services/penaltyGroup.service';
+import SignedHttpClient from '../../src/server/utils/httpclient';
+import MockedBackendAPI from '../utils/mockedBackendAPI';
+import penalties from '../data/penalties';
+import penaltyGroups from '../data/penaltyGroups';
+
+use(chaiAsPromised);
+
+const httpClient = new SignedHttpClient('');
+
+describe('Penalty Group Service', () => {
+  const mockedBackendAPI = new MockedBackendAPI(penalties, penaltyGroups);
+
+  let mockedHttpClient;
+  let penaltyGroupService;
+
+  afterEach(() => {
+    mockedHttpClient.restore();
+    penaltyGroupService = undefined;
+  });
+
+  describe('Retrieves a penalty group by payment code', () => {
+    it('Should retrieve the correct penalty group [WHEN] a valid multiple penalty payment code is provided', async () => {
+      // Arrange
+      const multiplePenaltyPaymentCode = 'f31r82ismx';
+
+      mockedHttpClient = sinon.stub(httpClient, 'get').callsFake(code => mockedBackendAPI.getPenaltyGroupByPaymentCode(code));
+      penaltyGroupService = new PenaltyGroupService();
+      penaltyGroupService.httpClient = mockedHttpClient.rootObj;
+
+      // Act
+      const result = await penaltyGroupService.getByPenaltyGroupPaymentCode(multiplePenaltyPaymentCode);
+
+      // Assert
+      expect(result.paymentCode).to.equal(multiplePenaltyPaymentCode);
+      sinon.assert.calledWith(mockedHttpClient, 'penaltyGroup/f31r82ismx');
+    });
+
+    it('Should return a rejected promise [WHEN] an invalid payment code is provided', () => {
+      // Arrange
+      const invalidPaymentCode = 'abc12345678';
+
+      mockedHttpClient = sinon.stub(httpClient, 'get').callsFake(code => mockedBackendAPI.getPenaltyByPaymentCode(code));
+      penaltyGroupService = new PenaltyGroupService(mockedHttpClient.rootObj);
+
+      // Act
+      const result = penaltyGroupService.getByPenaltyGroupPaymentCode(invalidPaymentCode);
+
+      // Assert
+      return expect(result).to.be.rejected;
+    });
+  });
+});

--- a/test/utils/mockedBackendAPI.js
+++ b/test/utils/mockedBackendAPI.js
@@ -1,6 +1,7 @@
 export default class MockedBackEndAPI {
-  constructor(penalties) {
+  constructor(penalties, penaltyGroups) {
     this.penalties = penalties;
+    this.penaltyGroups = penaltyGroups;
   }
 
   getPenaltyByPaymentCode(requestUrl) {
@@ -12,6 +13,21 @@ export default class MockedBackEndAPI {
         data: {
           Value: result,
           ID: `${result.referenceNo}_${result.penaltyType}`,
+        },
+      });
+    }
+
+    return Promise.reject(new Error('Invalid Payment Code'));
+  }
+
+  getPenaltyGroupByPaymentCode(requestUrl) {
+    const code = requestUrl.split('/').pop();
+    const result = this.penaltyGroups.find(pg => pg.ID === code);
+
+    if (result) {
+      return Promise.resolve({
+        data: {
+          ...result,
         },
       });
     }


### PR DESCRIPTION
* Add a route for `/payment-code/:payment_code/:type/payment` through to the payment redirection controller
*  Fetch penalty group from document service where payment code length isn't 16
* Create function in payment service to call CPMS orchestration service with details of all penalties of a given type