### PR TITLE
RSP-1190: Enhancements to CPMS multi card payment call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ typings/
 dist/
 build/
 .serverless/
+.vscode/

--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -37,7 +37,7 @@ const redirectForSinglePenalty = (req, res, penaltyDetails) => {
 };
 
 const redirectForPenaltyGroup = (req, res, penaltyGroupDetails, penaltyGroupType) => {
-  const redirectUrl = `https://${req.get('host')}${config.urlRoot}/payment-code/${penaltyGroupDetails.paymentCode}/confirmPayment`;
+  const redirectUrl = `https://${req.get('host')}${config.urlRoot}/payment-code/${penaltyGroupDetails.paymentCode}/receipt`;
   const penaltyOverviewsForType = penaltyGroupDetails.penaltyDetails
     .find(grouping => grouping.type === penaltyGroupType).penalties;
   const amountForType = penaltyOverviewsForType.reduce((total, pen) => total + pen.amount, 0);

--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -43,6 +43,7 @@ const redirectForPenaltyGroup = (req, res, penaltyGroupDetails, penaltyGroupType
   const amountForType = penaltyOverviewsForType.reduce((total, pen) => total + pen.amount, 0);
 
   return cpmsService.createGroupCardPaymentTransaction(
+    penaltyGroupDetails.paymentCode,
     amountForType,
     penaltyGroupDetails.penaltyGroupDetails.registrationNumber,
     penaltyGroupType,

--- a/src/server/services/cpms.service.js
+++ b/src/server/services/cpms.service.js
@@ -15,13 +15,14 @@ export default class PaymentService {
     });
   }
 
-  createGroupCardPaymentTransaction(amount, vehicleReg, type, penaltyOverviews, redirectUrl) {
+  createGroupCardPaymentTransaction(penGrpId, amount, vehicleReg, type, penOverviews, redirectUrl) {
     return this.httpClient.post('groupCardPayment/', {
+      PenaltyGroupId: penGrpId,
       TotalAmount: amount,
       VehicleRegistration: vehicleReg,
       PenaltyType: type,
       RedirectUrl: redirectUrl,
-      Penalties: penaltyOverviews.map(PaymentService.sanitisePenaltyForCpmsGroupCall),
+      Penalties: penOverviews.map(PaymentService.sanitisePenaltyForCpmsGroupCall),
     });
   }
 

--- a/test/controllers/payment.controller.spec.js
+++ b/test/controllers/payment.controller.spec.js
@@ -131,7 +131,7 @@ describe('Payment Controller', () => {
             nextPayment: null,
           });
         mockCpmsSvcGroup
-          .withArgs(150, '11ABC', 'FPN', fakePenaltyDetails[0].penalties, 'https://localhost/payment-code/46uu8efys1o/confirmPayment')
+          .withArgs('46uu8efys1o', 150, '11ABC', 'FPN', fakePenaltyDetails[0].penalties, 'https://localhost/payment-code/46uu8efys1o/receipt')
           .resolves({ data: { gateway_url: 'http://cpms.gateway' } });
 
         await PaymentController.redirectToPaymentPage(requestForPaymentCode('46uu8efys1o'), responseHandle);

--- a/test/services/cpms.service.spec.js
+++ b/test/services/cpms.service.spec.js
@@ -56,9 +56,10 @@ describe('Payment Service', () => {
         },
       ];
 
-      const returned = cpmsService.createGroupCardPaymentTransaction(150, '11ABC, 22XYZ', 'FPN', penaltyOverviews, 'http://redirect');
+      const returned = cpmsService.createGroupCardPaymentTransaction('11111111111', 150, '11ABC, 22XYZ', 'FPN', penaltyOverviews, 'http://redirect');
 
       sinon.assert.calledWith(mockHttpClient, 'groupCardPayment/', {
+        PenaltyGroupId: '11111111111',
         TotalAmount: 150,
         VehicleRegistration: '11ABC, 22XYZ',
         PenaltyType: 'FPN',


### PR DESCRIPTION
* Switch CPMS successful redirect URL leaf from `/cardPayment` to `/receipt`
* Add `PenaltyGroupId` to CPMS card payment payload