### PR TITLE
Enhancements to confirmGroupPayment route

### DIFF
--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -135,7 +135,7 @@ export const confirmGroupPayment = async (req, res) => {
         confirmResp,
       );
       await paymentService.recordGroupPayment(payload);
-      res.redirect(`/payment-code/${penaltyGroupDetails.paymentCode}/receipt`);
+      res.redirect(`/payment-code/${penaltyGroupDetails.paymentCode}/${type}/receipt`);
     } else {
       res.render('payment/failedPayment');
     }

--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -101,8 +101,12 @@ export const confirmPayment = async (req, res) => {
             PaymentDate: Math.round((new Date()).getTime() / 1000),
           },
         };
-        paymentService.makePayment(details).then(() => res.redirect(`${config.urlRoot}/payment-code/${penaltyDetails.paymentCode}`))
-          .catch(() => res.redirect(`${config.urlRoot}/payment-code/${penaltyDetails.paymentCode}`));
+        paymentService.makePayment(details)
+          .then(() => res.redirect(`${config.urlRoot}/payment-code/${penaltyDetails.paymentCode}`))
+          .catch((error) => {
+            logger.error(error);
+            res.redirect(`${config.urlRoot}/payment-code/${penaltyDetails.paymentCode}`);
+          });
       } else {
         logger.warn(response.data);
         res.render('payment/failedPayment');

--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -120,9 +120,9 @@ export const confirmPayment = async (req, res) => {
 export const confirmGroupPayment = async (req, res) => {
   try {
     const paymentCode = req.params.payment_code;
+    const receiptReference = req.query.receipt_reference;
     const { type } = req.params;
     const penaltyGroupDetails = await getPenaltyOrGroupDetails(req);
-    const receiptReference = `${paymentCode}_${type}`;
 
     const confirmResp = await cpmsService.confirmPayment(receiptReference, type);
 

--- a/test/controllers/payment.controller.spec.js
+++ b/test/controllers/payment.controller.spec.js
@@ -154,6 +154,9 @@ describe('Payment Controller', () => {
         payment_code: 'codenotlength16',
         type: 'FPN',
       },
+      query: {
+        receipt_reference: 'ref',
+      },
     };
     const penaltyGroupDetails = {
       paymentCode: 'codenotlength16',
@@ -172,7 +175,7 @@ describe('Payment Controller', () => {
       PenaltyType: 'FPN',
       PaymentDetail: {
         PaymentMethod: 'CARD',
-        PaymentRef: 'codenotlength16_FPN',
+        PaymentRef: 'ref',
         AuthCode: '111',
         PaymentAmount: '150',
         PaymentDate: sinon.match.number,
@@ -195,7 +198,7 @@ describe('Payment Controller', () => {
         .resolves(penaltyGroupDetails);
 
       mockCpmsSvc
-        .withArgs('codenotlength16_FPN', 'FPN')
+        .withArgs('ref', 'FPN')
         .resolves({ data: { code: 801, auth_code: '111' } });
       mockPaymentSvc
         .withArgs(expectedPaymentPayload)
@@ -219,7 +222,7 @@ describe('Payment Controller', () => {
     context('when CPMS confirms payment with response code 801', () => {
       it('should redirect to the receipt page', async () => {
         await PaymentController.confirmGroupPayment(req, resp);
-        sinon.assert.calledWith(mockCpmsSvc, 'codenotlength16_FPN', 'FPN');
+        sinon.assert.calledWith(mockCpmsSvc, 'ref', 'FPN');
         sinon.assert.calledWith(mockPaymentSvc, expectedPaymentPayload);
         sinon.assert.calledWith(redirectSpy, '/payment-code/codenotlength16/receipt');
       });

--- a/test/controllers/payment.controller.spec.js
+++ b/test/controllers/payment.controller.spec.js
@@ -224,7 +224,7 @@ describe('Payment Controller', () => {
         await PaymentController.confirmGroupPayment(req, resp);
         sinon.assert.calledWith(mockCpmsSvc, 'ref', 'FPN');
         sinon.assert.calledWith(mockPaymentSvc, expectedPaymentPayload);
-        sinon.assert.calledWith(redirectSpy, '/payment-code/codenotlength16/receipt');
+        sinon.assert.calledWith(redirectSpy, '/payment-code/codenotlength16/FPN/receipt');
       });
     });
 


### PR DESCRIPTION
* When coming back from CPMS -> `confirmGroupPayment`, use the
  `receipt_reference` query parameter to call CPMS service confirm and
  payment service group payment record create
* Ensure multi penalty payment type is included in post-CPMS receipt URL