### PR TITLE
Bugfix/multipenalty template enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11039,9 +11039,9 @@
       }
     },
     "moment": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
-      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "helmet": "^3.12.0",
     "i18n-express": "^1.1.3",
     "lodash": "^4.17.5",
-    "moment": "^2.21.0",
+    "moment": "^2.22.2",
     "node-dir": "^0.1.17",
     "nunjucks": "^3.0.1",
     "resolve-path": "^1.3.3",

--- a/src/public/scss/styles.scss
+++ b/src/public/scss/styles.scss
@@ -58,6 +58,20 @@ table.details {
   }
 }
 
+table.receipt-details {
+  td {
+    width: 50%;
+  }
+}
+
+table#receipt-breakdown {
+  margin-top: 30px;
+}
+
+div#send-receipt-button-container {
+  margin: 25px 0px;
+}
+
 .error, 
 .unconfirmed {
   color: $error-colour;

--- a/src/server/controllers/receipt.controller.js
+++ b/src/server/controllers/receipt.controller.js
@@ -39,12 +39,14 @@ function isValidPaymentPaymentType(type) {
 
 function addFormattedPaymentDateTimes(paymentDetails) {
   const newPaymentDetails = { ...paymentDetails };
-  const paymentTypes = Object.keys(newPaymentDetails.Payments);
-  for (let i = 0; i < paymentTypes.length; i += 1) {
-    const payment = newPaymentDetails.Payments[paymentTypes[i]];
-    const timestamp = payment.PaymentDate * 1000;
-    payment.FormattedDate = moment(timestamp).format('DD/MM/YYYY');
-    payment.FormattedTime = moment(timestamp).format('h:mma');
-  }
+  newPaymentDetails.Payments = Object.keys(newPaymentDetails.Payments).reduce((acc, type) => {
+    const timestamp = newPaymentDetails.Payments[type].PaymentDate * 1000;
+    acc[type] = {
+      FormattedDate: moment(timestamp).format('DD/MM/YYYY'),
+      FormattedTime: moment(timestamp).format('h:mma'),
+      ...newPaymentDetails.Payments[type],
+    };
+    return acc;
+  }, {});
   return newPaymentDetails;
 }

--- a/src/server/views/payment/multiPaymentInfo.njk
+++ b/src/server/views/payment/multiPaymentInfo.njk
@@ -58,25 +58,23 @@
               <td>&pound;{{ penaltyDetails.amount }}</td>
             </tr>
           {% else %}
-            {% for amount in penaltyGroupDetails.splitAmounts %}
+            {% for amount in penaltyGroupDetails.splitAmounts|sort(attribute='type', reverse=true) %}
               {% set amountPaid = true if amount.status == 'PAID' else false %}
               {% set statusClass = 'confirmed' if amountPaid else 'unconfirmed' %}
-              {% if amount.type == 'FPN' %}
-                <tr>
-                  <td>{{ t.penalty_details.FPN }}:</td>
-                  <td>&pound;{{ amount.amount }} <span class="{{statusClass}}">{% if amountPaid %}{{ t.penalty_details.status_paid }} &nbsp;&nbsp;<img src="{{ assets }}/images/icon-check.png" />{% else %}{{ t.penalty_details.status_unpaid }} {% endif %}</span></td>
-                </tr>
-                {% elif amount.type == 'IM' %}
-                  <tr>
-                    <td>{{ t.penalty_details.IM }}:</td>
-                    <td>&pound;{{ amount.amount }} <span class="{{statusClass}}">{% if amountPaid %}{{ t.penalty_details.status_paid }} &nbsp;&nbsp;<img src="{{ assets }}/images/icon-check.png" />{% else %}{{ t.penalty_details.status_unpaid }} {% endif %}</span></td>
-                  </tr>
-                {% elif amount.type == 'CDN' %}
-                  <tr>
-                    <td>{{ t.penalty_details.CDN }}:</td>
-                    <td>&pound;{{ amount.amount }} <span class="{{statusClass}}">{% if amountPaid %}{{ t.penalty_details.status_paid }} &nbsp;&nbsp;<img src="{{ assets }}/images/icon-check.png" />{% else %}{{ t.penalty_details.status_unpaid }} {% endif %}</span></td>
-                  </tr>
-              {% endif %}
+              <tr>
+                <td>{{ t.penalty_details[amount.type] }}:</td>
+                <td>
+                  &pound;{{ amount.amount }}
+                  <span class="{{statusClass}}">
+                    {% if amountPaid %}
+                      {{ t.penalty_details.status_paid }} &nbsp;&nbsp;
+                      <img src="{{ assets }}/images/icon-check.png" />
+                    {% else %}
+                      {{ t.penalty_details.status_unpaid }}
+                    {% endif %}
+                  </span>
+                </td>
+              </tr>
             {% endfor %}
           {% endif %}    
           {% if isPenaltyGroup == false %}

--- a/src/server/views/payment/multiPaymentReceipt.njk
+++ b/src/server/views/payment/multiPaymentReceipt.njk
@@ -21,16 +21,16 @@
       {% endfor %}
 
       <h3 class="heading-medium">{{ t.multipayment_receipt.transaction_receipt }}</h3>
-      <table>
+      <table class='receipt-details'>
         <tbody>
           <tr>
-            <td>{{ t.multipayment_receipt.transaction_amount }}
+            <td>{{ t.multipayment_receipt.transaction_amount }}</td>
               <td>
                 <strong>&pound;{{ paymentDetails.Payments[paymentType].PaymentAmount }}</strong>
               </td>
           </tr>
           <tr>
-            <td>{{ t.multipayment_receipt.transaction_date_time }}
+            <td>{{ t.multipayment_receipt.transaction_date_time }}</td>
             <td>
               <strong>
                 {{ paymentDetails.Payments[paymentType].FormattedDate }}
@@ -39,7 +39,8 @@
               </strong>
             </td>
           </tr>
-            <td>{{ t.multipayment_receipt.transaction_auth_code }}
+          <tr>
+            <td>{{ t.multipayment_receipt.transaction_auth_code }}</td>
             <td>
               <strong>{{ paymentDetails.Payments[paymentType].AuthCode }}</strong>
             </td>
@@ -50,7 +51,7 @@
       <h3 class="heading-medium">
         {{ t.multipayment_receipt.details_title[paymentType] }}
       </h3>
-      <table>
+      <table class='receipt-details'>
         <tbody>
           <tr>
             <td>{{ t.multipayment_receipt.details_registration }}</td>
@@ -67,7 +68,7 @@
         </tbody>
       </table>
 
-      <table>
+      <table id='receipt-breakdown'>
         <thead>
           <tr>
             <th>{{ t.multipayment_receipt.breakdown_reference }}</th>
@@ -98,9 +99,9 @@
 
       <h3 class="heading-medium">{{ t.multipayment_receipt.email.title }}</h3>
       {{ components.field(id='email_address', label=t.multipayment_receipt.email.address, hint=t.multipayment_receipt.email.description) }}
-      <p>
+      <div id="send-receipt-button-container">
         {{ components.button(text=t.multipayment_receipt.email.send, type="submit") }}
-      </p>
+      </div>
 
       {% if nextPayment %}
           <div class="notice">

--- a/src/server/views/payment/multiPaymentReceipt.njk
+++ b/src/server/views/payment/multiPaymentReceipt.njk
@@ -113,7 +113,7 @@
         </a>
       {% endif %}
       <p>
-        <a target='_blank' href='{{ urlroot }}/payment-code/{{ paymentCode }}'>{{ t.multipayment_receipt.back_to_summary }}</a>
+        <a href='{{ urlroot }}/payment-code/{{ paymentCode }}'>{{ t.multipayment_receipt.back_to_summary }}</a>
       </p>
     {%- endcall %}
   {%- endcall %}

--- a/src/server/views/payment/multiPaymentReceipt.njk
+++ b/src/server/views/payment/multiPaymentReceipt.njk
@@ -32,7 +32,11 @@
           <tr>
             <td>{{ t.multipayment_receipt.transaction_date_time }}
             <td>
-              <strong>{{ paymentDetails.Payments[paymentType].PaymentDate }}</strong>
+              <strong>
+                {{ paymentDetails.Payments[paymentType].FormattedDate }}
+                &nbsp;&nbsp;
+                {{ paymentDetails.Payments[paymentType].FormattedTime }}
+              </strong>
             </td>
           </tr>
             <td>{{ t.multipayment_receipt.transaction_auth_code }}

--- a/src/server/views/payment/multiPaymentSummary.njk
+++ b/src/server/views/payment/multiPaymentSummary.njk
@@ -40,11 +40,13 @@
               <td class="{{ statusClass }}"><strong>{{ penalty.status }}</strong></td>
             </tr>   
           {% endfor %}
-          <tr>
-            <td>{{ t.penalty_details.total_amount }}</td> 
-            <td><strong>&pound;{{ totalAmount if totalAmount else 'N/A' }}</strong></td> 
-            <td></td>
-          </tr>
+          {% if penaltyDetails.length > 1 %}
+            <tr>
+              <td>{{ t.penalty_details.total_amount }}</td> 
+              <td><strong>&pound;{{ totalAmount if totalAmount else 'N/A' }}</strong></td> 
+              <td></td>
+            </tr>
+          {% endif %}
         </tbody>
       </table>
       <br />

--- a/test/controllers/receipt.controller.spec.js
+++ b/test/controllers/receipt.controller.spec.js
@@ -23,7 +23,7 @@ describe('ReceiptController', () => {
         PaymentRef: 'RJF12345',
         AuthCode: '1234TBD',
         PaymentAmount: '80',
-        PaymentDate: 1519300376667,
+        PaymentDate: 1519300376,
         PaymentStatus: 'PAID',
       },
     },
@@ -53,7 +53,20 @@ describe('ReceiptController', () => {
       await ReceiptController(request, response);
       sinon.assert.calledWith(renderSpy, 'payment/multiPaymentReceipt', {
         paymentType: 'FPN',
-        paymentDetails: groupPaymentResp,
+        paymentDetails: {
+          ID: 'abcdefghij1',
+          Payments: {
+            IM: {
+              PaymentRef: 'RJF12345',
+              AuthCode: '1234TBD',
+              PaymentAmount: '80',
+              PaymentDate: 1519300376,
+              FormattedDate: '22/02/2018',
+              FormattedTime: '11:52am',
+              PaymentStatus: 'PAID',
+            },
+          },
+        },
         ...penaltyGroupSvcResp,
       });
     });


### PR DESCRIPTION
* Prevent back to multipayment summary link opening in new tab
* Sort types in multipenalty payment code overview so IM is first
* Only show multipenalty breakdown total for more than 1 penalty
* Add formatting to multipenalty receipt transaction datetime