### PR TITLE
Fix prod environment generating internal redirect URL

### DIFF
--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -22,7 +22,7 @@ const getPenaltyOrGroupDetails = (req) => {
 };
 
 const redirectForSinglePenalty = (req, res, penaltyDetails) => {
-  const redirectUrl = `https://${req.get('host')}${config.urlRoot}/payment-code/${penaltyDetails.paymentCode}/confirmPayment`;
+  const redirectUrl = `${req.get('origin')}${config.urlRoot}/payment-code/${penaltyDetails.paymentCode}/confirmPayment`;
 
   return cpmsService.createCardPaymentTransaction(
     penaltyDetails.vehicleReg,
@@ -40,7 +40,7 @@ const redirectForSinglePenalty = (req, res, penaltyDetails) => {
 };
 
 const redirectForPenaltyGroup = (req, res, penaltyGroupDetails, penaltyType) => {
-  const redirectUrl = `https://${req.get('host')}${config.urlRoot}/payment-code/${penaltyGroupDetails.paymentCode}/${penaltyType}/confirmGroupPayment`;
+  const redirectUrl = `${req.get('origin')}${config.urlRoot}/payment-code/${penaltyGroupDetails.paymentCode}/${penaltyType}/confirmGroupPayment`;
   const penaltyOverviewsForType = penaltyGroupDetails.penaltyDetails
     .find(grouping => grouping.type === penaltyType).penalties;
   const amountForType = penaltyOverviewsForType.reduce((total, pen) => total + pen.amount, 0);

--- a/test/controllers/payment.controller.spec.js
+++ b/test/controllers/payment.controller.spec.js
@@ -15,7 +15,7 @@ function requestForPaymentCode(paymentCode) {
     },
     get: (key) => {
       const gettables = {
-        host: 'localhost',
+        origin: 'http://localhost',
       };
       return gettables[key];
     },
@@ -77,7 +77,7 @@ describe('Payment Controller', () => {
             amount: 100,
           });
         mockCpmsSvcSingle
-          .withArgs('11ABC', '123', 'FPN', 100, 'https://localhost/payment-code/1111111111111111/confirmPayment')
+          .withArgs('11ABC', '123', 'FPN', 100, 'http://localhost/payment-code/1111111111111111/confirmPayment')
           .resolves({ data: { gateway_url: 'http://cpms.gateway' } });
 
         await PaymentController.redirectToPaymentPage(requestForPaymentCode('1111111111111111'), responseHandle);
@@ -132,7 +132,7 @@ describe('Payment Controller', () => {
             nextPayment: null,
           });
         mockCpmsSvcGroup
-          .withArgs('46uu8efys1o', 150, '11ABC', 'FPN', fakePenaltyDetails[0].penalties, 'https://localhost/payment-code/46uu8efys1o/FPN/confirmGroupPayment')
+          .withArgs('46uu8efys1o', 150, '11ABC', 'FPN', fakePenaltyDetails[0].penalties, 'http://localhost/payment-code/46uu8efys1o/FPN/confirmGroupPayment')
           .resolves({ data: { gateway_url: 'http://cpms.gateway' } });
 
         await PaymentController.redirectToPaymentPage(requestForPaymentCode('46uu8efys1o'), responseHandle);


### PR DESCRIPTION
* In prod, the redirect URL given to CPMS orchestration as the return
  endpoint from Capita is an unwhitelisted internal URL
* Use the origin header instead of the host header to build a public
  redirect URL