### PR TITLE
Prevent display of penalty group details where cancelled

### DIFF
--- a/src/server/controllers/paymentCode.controller.js
+++ b/src/server/controllers/paymentCode.controller.js
@@ -62,8 +62,12 @@ export const getPaymentDetails = [
         getMethod: 'getByPenaltyGroupPaymentCode',
         template: 'multiPaymentInfo',
       };
-      service[getMethod](paymentCode).then((data) => {
-        res.render(`payment/${template}`, data);
+      service[getMethod](paymentCode).then((entityData) => {
+        if (entityData.Enabled) {
+          res.render(`payment/${template}`, entityData);
+        } else {
+          res.redirect('../payment-code?invalidPaymentCode');
+        }
       }).catch((error) => {
         logger.error(error);
         res.redirect('../payment-code?invalidPaymentCode');

--- a/src/server/services/penalty.service.js
+++ b/src/server/services/penalty.service.js
@@ -47,7 +47,7 @@ export default class PenaltyService {
   getByPaymentCode(paymentCode) {
     const promise = new Promise((resolve, reject) => {
       this.httpClient.get(`documents/tokens/${paymentCode}`).then((response) => {
-        if (isEmpty(response.data) || response.data.Enabled === false) {
+        if (isEmpty(response.data)) {
           reject(new Error('Payment code not found'));
         }
         resolve(PenaltyService.parsePenalty(response.data));


### PR DESCRIPTION
The following PR adds a requirement for consumers of the penalty group API to handle the case where the group is disabled instead of relying on a 404.
https://github.com/dvsa/rsp-documents-service/pull/44