### PR TITLE
DAC Report Accessibility Fixes

### DIFF
--- a/src/public/js/dvsa/third-party/details-polyfill.js
+++ b/src/public/js/dvsa/third-party/details-polyfill.js
@@ -139,9 +139,6 @@
           details.__content.id = 'details-content-' + i;
         }
 
-        // Add ARIA role="group" to details
-        details.setAttribute('role', 'group');
-
         // Add role=button to summary
         details.__summary.setAttribute('role', 'button');
 

--- a/src/public/js/vendor/frontend-toolkit/govuk/details.polyfill.js
+++ b/src/public/js/vendor/frontend-toolkit/govuk/details.polyfill.js
@@ -139,9 +139,6 @@
           details.__content.id = 'details-content-' + i;
         }
 
-        // Add ARIA role="group" to details
-        details.setAttribute('role', 'group');
-
         // Add role=button to summary
         details.__summary.setAttribute('role', 'button');
 

--- a/src/server/i18n/cy.json
+++ b/src/server/i18n/cy.json
@@ -46,6 +46,7 @@
     "court_deposit": "Blaendaliadau'r llys",
     "info_text": "Os nad ydych yn talu dirwy ar amser, gellir parhau i atal eich cerbyd rhag symud, efallai y bydd yn rhaid i chi dalu mwy, neu efallai y byddwch chi'n cael eich cymryd i'r llys.",
     "language_guidance": "Mae'r dudalen hon hefyd ar gael yn Ffrangeg (<a href='?clang=fr'>Français</a>), Almaeneg (<a href='?clang=de'>Deutsch</a>), Pwyleg (<a href='?clang=pl'>Polski</a>), Sbaeneg (<a href='?clang=es'>Español</a>) a Saesneg (<a href='?clang=en'>English</a>)",
+    "language_guidance_header": "Mae'r dudalen hon hefyd ar gael yn",
     "start_button": "Dechrau nawr",
     "before_start": "Cyn i chi ddechrau",
     "before_start_text": "Bydd arnoch angen:",

--- a/src/server/i18n/de.json
+++ b/src/server/i18n/de.json
@@ -46,6 +46,7 @@
     "court_deposit": "Einer Gerichtskaution",
     "info_text": "Wenn Sie Ihr Bußgeld nicht fristgerecht bezahlen, kann Ihr Fahrzeug stillgelegt bleiben und die Angaben zu Ihrer Person können an eine Inkassogesellschaft weitergeleitet werden.",
     "language_guidance": "Diese Seite gibt es auch in Französischer (<a href='?clang=fr'>Français</a>), Polnischer (<a href='?clang=pl'>Polski</a>), Spanischer (<a href='?clang=es'>Español</a>), Englisch (<a href='?clang=en'>English</a>) und Walisischer (<a href='?clang=cy'>Cymraeg</a>) Sprache",
+    "language_guidance_header": "Diese Seite gibt es auch in",
     "start_button": "Beginnen Sie jetzt",
     "before_start": "Bevor Sie beginnen",
     "before_start_text": "Brauchen Sie:",

--- a/src/server/i18n/en.json
+++ b/src/server/i18n/en.json
@@ -46,6 +46,7 @@
     "court_deposit": "Court deposits",
     "info_text": "If you don't pay a fine on time, your vehicle could be immobilised, you might have to pay more, or you could be taken to court.  ",
     "language_guidance": "This page is also available in French (<a href='?clang=fr'>Français</a>), German (<a href='?clang=de'>Deutsch</a>), Polish  (<a href='?clang=pl'>Polski</a>), Spanish (<a href='?clang=es'>Español</a>) and Welsh (<a href='?clang=cy'>Cymraeg</a>)",
+    "language_guidance_header": "This page is also available in",
     "start_button": "Start now",
     "before_start": "Before you start",
     "before_start_text": "You will need:",

--- a/src/server/i18n/es.json
+++ b/src/server/i18n/es.json
@@ -46,6 +46,7 @@
     "court_deposit": "Depósitos judiciales",
     "info_text": "Si no paga la multa a tiempo su vehículo podrá ser inmovilizado, podrá tener que pagar más o podría ser procesado judicialmente.",
     "language_guidance": "Esta página está también disponible en Francés (<a href='?clang=fr'>Français</a>), Alemán (<a href='?clang=de'>Deutsch</a>), Polaco (<a href='?clang=pl'>Polski</a>), Inglés (<a href='?clang=en'>English</a>) y Galés (<a href='?clang=cy'>Cymraeg</a>)",
+    "language_guidance_header": "Esta página está también disponible en",
     "start_button": "Empezar ahora",
     "before_start": "Antes de empezar",
     "before_start_text": "Necesitará:",

--- a/src/server/i18n/fr.json
+++ b/src/server/i18n/fr.json
@@ -46,6 +46,7 @@
 		"court_deposit": "Un dépôt auprès du tribunal",
 		"info_text": "Si vous ne payez pas votre amende à temps, votre véhicule restera immobilisé ou vos informations seront transmises à une agence de recouvrement de créances.",
 		"language_guidance": "Cette page est également disponible en Allemand (<a href='?clang=de'>Deutsch</a>), Polonais (<a href='?clang=pl'>Polski</a>), Espagnol (<a href='?clang=es'>Español</a>), Anglais (<a href='?clang=en'>English</a>) et Gallois (<a href='?clang=cy'>Cymraeg</a>)",
+		"language_guidance_header": "Cette page est également disponible en",
 		"start_button": "Commencer maintenant",
 		"before_start": "Avant de commencer",
 		"before_start_text": "Vous aurez besoin de : ",

--- a/src/server/i18n/pl.json
+++ b/src/server/i18n/pl.json
@@ -46,6 +46,7 @@
     "court_deposit": "Depozyt sądowy ",
     "info_text": "Jeśli nie zapłacą Państwo kary w terminie, pojazd może pozostać unieruchomiony lub mogą Państwo zostać wezwani do sądu.",
     "language_guidance": "Strona ta jest również dostępna w języku Francuskim (<a href='?clang=fr'>Français</a>), Niemieckim (<a href='?clang=de'>Deutsch</a>),  Angielski (<a href='?clang=en'>English</a>), Hiszpańskim (<a href='?clang=es'>Español</a>) i Walijskim (<a href='?clang=cy'>Cymreag</a>)",
+    "language_guidance_header": "Strona ta jest również dostępna w języku",
     "start_button": "Zacznij teraz",
     "before_start": "Zanim zaczniesz",
     "before_start_text": "Będziesz potrzebować:",

--- a/src/server/views/layouts/partials/footer.njk
+++ b/src/server/views/layouts/partials/footer.njk
@@ -3,7 +3,7 @@
   <div class="footer-wrapper">
     <div class="footer-meta">
       <div class="footer-meta-inner">
-        <h2 class="visuallyhidden">Support links</h2>
+        <h5 class="visuallyhidden">Support links</h5>
         <ul>
           <li><a href="https://www.gov.uk/help/cookies">{{ t.footer.cookies }}</a></li>
           <li><a href="https://www.gov.uk/help/terms-conditions">{{ t.footer.terms_conditions }}</a></li>

--- a/src/server/views/macros/elements/label.njk
+++ b/src/server/views/macros/elements/label.njk
@@ -2,12 +2,12 @@
   {% if label %}
     <label class="form-label {{ 'form-label-bold' if bold }} {{ 'visuallyhidden' if visuallyHidden }}" {{ 'for="' + id + '"' if id }}>
       {{ label }}
-      {% if hint %}
-        <span class="form-hint">{{ hint }}</span>
-      {% endif %}
-      {% if error %}
-        <span class="error-message">{{ error }}</span>
-      {% endif %}
     </label>
+    {% if hint %}
+      <span class="form-hint">{{ hint }}</span>
+    {% endif %}
+    {% if error %}
+      <span class="error-message">{{ error }}</span>
+    {% endif %}
   {% endif %}
 {% endmacro %}

--- a/src/server/views/macros/typography/headings.njk
+++ b/src/server/views/macros/typography/headings.njk
@@ -1,6 +1,6 @@
-{% macro heading(text='', secondary=false, tag='h1', size='large', url=false, extraClass) %}
+{% macro heading(text='', secondary=false, tag='h1', size='large', url=false, extraClass, id) %}
   {% if text %}
-    <{{ tag }} class="heading {{ 'heading--' + size if size }} {{ extraClass if extraClass }} heading-{{ size }}">
+    <{{ tag }} {{ 'id="' + id + '"' if id }} class="heading {{ 'heading--' + size if size }} {{ extraClass if extraClass }} heading-{{ size }}">
       {% if secondary %}
         <span class="heading__secondary">{{ secondary }}</span>
       {% endif %}

--- a/src/server/views/main/index.njk
+++ b/src/server/views/main/index.njk
@@ -55,8 +55,8 @@
     {% call components.columnOneThird() %}
 
     <aside class="govuk-related-items" role="complementary">
-      {{ components.heading(text='Related content', tag='h3', size='medium') }}
-        <nav role="navigation" aria-labelledby="subsection-title">
+      {{ components.heading(text='Related content', tag='h3', size='medium', id='related-content-header') }}
+        <nav role="navigation" aria-labelledby="related-content-header">
           <ul class="font-xsmall">
             <li>{{ components.link(text=t.home.related_content_link_1, url='https://www.gov.uk/roadside-vehicle-checks-for-commercial-drivers') }}</li>
             <li>{{ components.link(text=t.home.related_content_link_2, url='https://www.gov.uk/drivers-hours') }}</li>

--- a/src/server/views/payment/index.njk
+++ b/src/server/views/payment/index.njk
@@ -16,7 +16,7 @@
         {{ components.heading(text=t.payment_code_page.title, tag='h1', size='xlarge') }}
         
         {% if invalidPaymentCode %}
-          <div class="error-summary" role="alert" aria-labelledby="error-summary-payment-code" tabindex="-1">
+          <div class="error-summary" role="alert" aria-labelledby="error-summary-payment-code" tabindex="1">
             <h2 class="heading-medium error-summary-heading" id="error-summary-payment-code">
               {{ t.payment_code_page.error.title }}
             </h2>

--- a/src/server/views/payment/multiPaymentInfo.njk
+++ b/src/server/views/payment/multiPaymentInfo.njk
@@ -53,7 +53,7 @@
                 <span class="{{statusClass}}">
                   {% if amountPaid %}
                     <strong>{{ t.penalty_details.status_paid }}</strong> &nbsp;&nbsp;
-                    <img src="{{ assets }}/images/icon-check.png" />
+                    <img src="{{ assets }}/images/icon-check.png" alt="" />
                   {% else %}
                     <strong>{{ t.penalty_details.status_unpaid }}</strong>
                   {% endif %}

--- a/src/server/views/payment/multiPaymentInfo.njk
+++ b/src/server/views/payment/multiPaymentInfo.njk
@@ -157,6 +157,7 @@
     {%- endcall %}
     {% call components.columnOneThird() %}
     <aside class="govuk-related-items" role="complementary">
+        <p>{{ t.home.language_guidance_header }}:</p>
         <nav role="navigation" aria-labelledby="subsection-title">
           <ul class="font-xsmall">
             <li>{{ components.link(text='Cymraeg', url='?clang=cy') if clang != 'cy' else components.link(text='English', url='?clang=en') }}</li>

--- a/src/server/views/payment/multiPaymentInfo.njk
+++ b/src/server/views/payment/multiPaymentInfo.njk
@@ -157,8 +157,8 @@
     {%- endcall %}
     {% call components.columnOneThird() %}
     <aside class="govuk-related-items" role="complementary">
-        <p>{{ t.home.language_guidance_header }}:</p>
-        <nav role="navigation" aria-labelledby="subsection-title">
+        <p id='language-links-header'>{{ t.home.language_guidance_header }}:</p>
+        <nav role="navigation" aria-labelledby="language-links-header">
           <ul class="font-xsmall">
             <li>{{ components.link(text='Cymraeg', url='?clang=cy') if clang != 'cy' else components.link(text='English', url='?clang=en') }}</li>
             <li>{{ components.link(text='Deutsch', url='?clang=de') if clang != 'de' else components.link(text='English', url='?clang=en') }}</li>

--- a/src/server/views/payment/multiPaymentReceipt.njk
+++ b/src/server/views/payment/multiPaymentReceipt.njk
@@ -100,7 +100,7 @@
                         {% if penalty.status == 'PAID' %}
                           {{ t.penalty_details.status_paid }}
                           &nbsp;&nbsp;
-                          <img src="{{ assets }}/images/icon-check.png" />
+                          <img src="{{ assets }}/images/icon-check.png" alt="" />
                         {% else %}
                           {{ t.penalty_details.status_unpaid }}
                         {% endif %}

--- a/src/server/views/payment/paymentDetails.njk
+++ b/src/server/views/payment/paymentDetails.njk
@@ -49,7 +49,17 @@
                 <td>{{ t.penalty_details.type_immobilisation }}</td>
               {% endif %}
               <td>&pound;{{ amount }}</td>
-              <td id="status" class="{{ statusClass }}"><strong>{% if paid %}{{ t.penalty_details.status_paid }} &nbsp;&nbsp;<img src="{{ assets }}/images/icon-check.png" />{% else %}{{ t.penalty_details.status_unpaid }} {% endif %}</strong></td>
+              <td id="status" class="{{ statusClass }}">
+                <strong>
+                  {% if paid %}
+                    {{ t.penalty_details.status_paid }}
+                    &nbsp;&nbsp;
+                    <img src="{{ assets }}/images/icon-check.png" alt="" />
+                  {% else %}
+                    {{ t.penalty_details.status_unpaid }}
+                  {% endif %}
+                </strong>
+              </td>
             </tr>
             <tr>
               <td>{{ t.penalty_details.reference}}</td>

--- a/src/server/views/payment/paymentDetails.njk
+++ b/src/server/views/payment/paymentDetails.njk
@@ -136,8 +136,8 @@
     {%- endcall %}
     {% call components.columnOneThird() %}
       <aside class="govuk-related-items" role="complementary">
-        <p>{{ t.home.language_guidance_header }}:</p>
-        <nav role="navigation" aria-labelledby="subsection-title">
+        <p id='language-links-header'>{{ t.home.language_guidance_header }}:</p>
+        <nav role="navigation" aria-labelledby="language-links-header">
           <ul class="font-xsmall">
             <li>{{ components.link(text='Cymraeg', url='?clang=cy') if clang != 'cy' else components.link(text='English', url='?clang=en') }}</li>
             <li>{{ components.link(text='Deutsch', url='?clang=de') if clang != 'de' else components.link(text='English', url='?clang=en') }}</li>

--- a/src/server/views/payment/paymentDetails.njk
+++ b/src/server/views/payment/paymentDetails.njk
@@ -125,7 +125,8 @@
       {%- endcall %}
     {%- endcall %}
     {% call components.columnOneThird() %}
-    <aside class="govuk-related-items" role="complementary">
+      <aside class="govuk-related-items" role="complementary">
+        <p>{{ t.home.language_guidance_header }}:</p>
         <nav role="navigation" aria-labelledby="subsection-title">
           <ul class="font-xsmall">
             <li>{{ components.link(text='Cymraeg', url='?clang=cy') if clang != 'cy' else components.link(text='English', url='?clang=en') }}</li>


### PR DESCRIPTION
* RSP-1576: Add instructive header above summary page language links
* RSP-1572: Add empty alt attribute to decorative PAID status tick icons
* RSP-1573: Fix invalid aria-labelledby attributes on all side navs
* RSP-1574: Adjust details polyfill to omit role="group" attribute
* RSP-1579: Move field macro description outside of label element
* RSP-1578: Ensure payment code search error summary is the first tabstop
* RSP-1581: Change hidden footer heading to h5 to fix illogical hierarchy