### PR TITLE
RSP-1552: Receipt table layout

### DIFF
--- a/src/public/scss/styles.scss
+++ b/src/public/scss/styles.scss
@@ -75,16 +75,15 @@ table.single-penalty-summary {
 }
 
 table.receipt-details {
-  td {
-    width: 50%;
+  td:first-child {
+    width: 33%;
   }
 }
 
 table#receipt-breakdown {
-  margin-top: 30px;
   tr {
     td:first-child {
-      width: 50%;
+      width: 33%;
     }
   }
 }
@@ -98,7 +97,7 @@ tr.no-border {
 table#receipt-penalty-details {
   tr {
     td:first-child {
-      width: 50%;
+      width: 33%;
     }
   }
 }

--- a/src/server/views/payment/multiPaymentReceipt.njk
+++ b/src/server/views/payment/multiPaymentReceipt.njk
@@ -79,44 +79,35 @@
       </table>
 
       <table id='receipt-breakdown'>
-        <thead>
-          <tr>
-            <td>{{ t.penalty_details.reference }}</td>
-            <td>{{ t.penalty_details.amount }}</td>
-            <td>{{ t.penalty_details.status }}</td>
-          </tr>
-        </thead>
-        <tbody>
-          {% for payment in penaltyDetails %}
-            {% if payment.type == paymentType %}
-              {% for penalty in payment.penalties %}
-                {% set statusClass = 'confirmed' if penalty.status == 'PAID' else 'unconfirmed' %}
-                <tr>
-                  <td><strong>{{ penalty.formattedReference }}</strong></td>
-                  <td><strong>&pound;{{ penalty.amount }}</strong></td>
-                  <td>
-                    <strong>
-                      <span class='{{ statusClass }}'>
-                        {% if penalty.status == 'PAID' %}
-                          {{ t.penalty_details.status_paid }}
-                          &nbsp;&nbsp;
-                          <img src="{{ assets }}/images/icon-check.png" alt="" />
-                        {% else %}
-                          {{ t.penalty_details.status_unpaid }}
-                        {% endif %}
-                      </span>
-                    </strong>
-                  </td>
-                </tr>
-              {% endfor %}
-            {% endif %}
-          {% endfor %}
-        </tbody>
+        {% for payment in penaltyDetails %}
+          {% if payment.type == paymentType %}
+            {% for penalty in payment.penalties %}
+              {% set statusClass = 'confirmed' if penalty.status == 'PAID' else 'unconfirmed' %}
+              <tr>
+                <td>Reference</td>
+                <td><strong>{{ penalty.formattedReference }}</strong></td>
+                <td><strong>&pound;{{ penalty.amount }}</strong></td>
+                <td>
+                  <strong>
+                    <span class='{{ statusClass }}'>
+                      {% if penalty.status == 'PAID' %}
+                        {{ t.penalty_details.status_paid }}
+                        &nbsp;&nbsp;
+                        <img src="{{ assets }}/images/icon-check.png" alt="" />
+                      {% else %}
+                        {{ t.penalty_details.status_unpaid }}
+                      {% endif %}
+                    </span>
+                  </strong>
+                </td>
+              </tr>
+            {% endfor %}
+          {% endif %}
+        {% endfor %}
       </table>
       <table id='receipt-penalty-details'>
         <tr>
           <td>{{ t.penalty_details.vehicle_reg }}</td>
-          <td><strong>{{ penaltyGroupDetails.registrationNumber }}</strong></td>
           <td><strong>{{ penaltyGroupDetails.registrationNumber.replace(',', ', ') }}</strong></td>
         </tr>
         <tr>

--- a/src/server/views/payment/multiPaymentReceipt.njk
+++ b/src/server/views/payment/multiPaymentReceipt.njk
@@ -117,6 +117,7 @@
         <tr>
           <td>{{ t.penalty_details.vehicle_reg }}</td>
           <td><strong>{{ penaltyGroupDetails.registrationNumber }}</strong></td>
+          <td><strong>{{ penaltyGroupDetails.registrationNumber.replace(',', ', ') }}</strong></td>
         </tr>
         <tr>
           <td>{{ t.penalty_details.penalty_date }}</td>


### PR DESCRIPTION
# Original layout

<img width="649" alt="screen shot 2018-12-12 at 14 10 56" src="https://user-images.githubusercontent.com/44976690/49875092-0ddc1f00-fe18-11e8-86ac-3d5a233f10f3.png">

# Updated layout

<img width="652" alt="screen shot 2018-12-12 at 14 12 51" src="https://user-images.githubusercontent.com/44976690/49875112-19c7e100-fe18-11e8-83a7-38b9c10db182.png">
