### PR TITLE
RSP-1710: Input validation

### DIFF
--- a/src/server/views/payment/multiPaymentInfo.njk
+++ b/src/server/views/payment/multiPaymentInfo.njk
@@ -42,7 +42,7 @@
           </tr>
           <tr>
             <td>{{ t.penalty_details.location }}</td>
-            <td colspan=4>{{ location }}</td>
+            <td colspan=4>{{ location | escape }}</td>
           </tr>
           {% for amount in penaltyGroupDetails.splitAmounts|sort(attribute='type', reverse=true) %}
             {% set amountPaid = true if amount.status == 'PAID' else false %}

--- a/src/server/views/payment/multiPaymentReceipt.njk
+++ b/src/server/views/payment/multiPaymentReceipt.njk
@@ -134,7 +134,7 @@
         </tr>
         <tr>
           <td>{{ t.penalty_details.location }}</td>
-          <td><strong>{{ location }}</strong></td>
+          <td><strong>{{ location | escape }}</strong></td>
         </tr>
       </table>
       <h3 class="heading-medium">{{ t.payment_details.payment_receipt_print_header  }}</h3>

--- a/src/server/views/payment/paymentDetails.njk
+++ b/src/server/views/payment/paymentDetails.njk
@@ -44,7 +44,7 @@
             </tr>
             <tr>
               <td>{{ t.penalty_details.location }}</td>
-              <td colspan=4>{{ location if complete else 'Not available' }}</td> 
+              <td colspan=4>{{ location | escape if complete else 'Not available' }}</td>
             </tr>
             <tr>
               {% if type == 'FPN' %}


### PR DESCRIPTION
Since autoescape is disabled to be compatible with the DVSA front end (see https://github.com/dvsa/front-end/blob/v1.3.2/src/server/app.js#L36), escaping has been done manually for location which is the only string field allowing special characters (https://mozilla.github.io/nunjucks/templating.html#escape-aliased-as-e).