### PR TITLE
RSP-1738: Orphaned payment fix

### DIFF
--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -31,6 +31,7 @@ const redirectForSinglePenalty = (req, res, penaltyDetails, redirectHost) => {
     penaltyDetails.type,
     penaltyDetails.amount,
     redirectUrl,
+    penaltyDetails.reference,
   ).then((response) => {
     logger.error(JSON.stringify(response.data));
     res.redirect(response.data.gateway_url);

--- a/src/server/services/cpms.service.js
+++ b/src/server/services/cpms.service.js
@@ -5,10 +5,13 @@ export default class PaymentService {
     this.httpClient = new SignedHttpClient(serviceUrl);
   }
 
-  createCardPaymentTransaction(paymentCode, reg, penaltyRef, penaltyType, amount, redirectUrl) {
+  createCardPaymentTransaction(paymentCode, reg, penaltyRef, penaltyType, amount, redirectUrl,
+    penaltyId,
+  ) {
     return this.httpClient.post('cardPayment/', {
       payment_code: paymentCode,
       penalty_reference: penaltyRef,
+      penalty_id: penaltyId,
       penalty_type: penaltyType,
       penalty_amount: amount,
       redirect_url: redirectUrl,

--- a/src/server/services/cpms.service.js
+++ b/src/server/services/cpms.service.js
@@ -5,7 +5,8 @@ export default class PaymentService {
     this.httpClient = new SignedHttpClient(serviceUrl);
   }
 
-  createCardPaymentTransaction(paymentCode, reg, penaltyRef, penaltyType, amount, redirectUrl,
+  createCardPaymentTransaction(
+    paymentCode, reg, penaltyRef, penaltyType, amount, redirectUrl,
     penaltyId,
   ) {
     return this.httpClient.post('cardPayment/', {

--- a/test/controllers/payment.controller.spec.js
+++ b/test/controllers/payment.controller.spec.js
@@ -72,7 +72,7 @@ describe('Payment Controller', () => {
 
       it('should redirect to the CPMS gateway URL returned when CPMS Service creates a transaction', async () => {
         mockCpmsSvcSingle
-          .withArgs('5e7a4c97c260e699', 'GHIYIN', '425782-0-253535-IM', 'IM', 50, 'https://localhost/payment-code/5e7a4c97c260e699/confirmPayment')
+          .withArgs('5e7a4c97c260e699', 'GHIYIN', '425782-0-253535-IM', 'IM', 50, 'https://localhost/payment-code/5e7a4c97c260e699/confirmPayment', '4257820253535')
           .resolves({ data: { gateway_url: 'http://cpms.gateway' } });
 
         await PaymentController.redirectToPaymentPage(requestForPaymentCode('5e7a4c97c260e699'), responseHandle);


### PR DESCRIPTION
Send unformatted reference to the `rsp-cpms-orchestration` `cardPayment` so `checkForOrphanedPayments` can retrieve a penalty document. Previously only sent the formatted reference. See https://github.com/dvsa/rsp-cpms-orchestration/pull/37 for more details.