### PR TITLE
Remove related links from home page

### DIFF
--- a/src/server/views/main/index.njk
+++ b/src/server/views/main/index.njk
@@ -53,18 +53,6 @@
     {%- endcall %}
 
     {% call components.columnOneThird() %}
-
-    <aside class="govuk-related-items" role="complementary">
-      {{ components.heading(text=t.home.related_content, tag='h3', size='small', id='related-content-header') }}
-        <nav role="navigation" aria-labelledby="related-content-header">
-          <ul class="font-xsmall">
-            <li>{{ components.link(text=t.home.related_content_link_1, url='https://www.gov.uk/roadside-vehicle-checks-for-commercial-drivers') }}</li>
-            <li>{{ components.link(text=t.home.related_content_link_2, url='https://www.gov.uk/drivers-hours') }}</li>
-            <li>{{ components.link(text=t.home.related_content_link_3, url='https://www.gov.uk/roadside-vehicle-checks-for-commercial-drivers/fixed-penalties') }}</li>
-            <li>{{ components.link(text=t.home.related_content_link_4, url='https://www.gov.uk/roadside-vehicle-checks-for-commercial-drivers/what-happens-if-your-vehicle-is-immobilised') }}</li>
-          </ul>
-        </nav>
-      </aside>
     {%- endcall %}
 
   {%- endcall %}


### PR DESCRIPTION
As requested by GDS.

Remove links from RHS of home page.

# Before

<img width="1680" alt="Screenshot 2019-06-11 at 09 34 56" src="https://user-images.githubusercontent.com/44976690/59256600-32c91780-8c2c-11e9-978a-c5c3424ca6b7.png">

# After

<img width="1680" alt="Screenshot 2019-06-11 at 09 27 38" src="https://user-images.githubusercontent.com/44976690/59256540-14fbb280-8c2c-11e9-98af-b37047e4a489.png">
