### PR TITLE
RSP-1831: Redirect to invalid search when penalty is more than 28 days old

### DIFF
--- a/src/server/controllers/main.controller.js
+++ b/src/server/controllers/main.controller.js
@@ -1,3 +1,5 @@
+import config from '../config';
+
 // Robots
 export const robots = (req, res) => {
   res.type('text/plain');
@@ -7,6 +9,9 @@ export const robots = (req, res) => {
 // Index Route
 export const index = (req, res) => {
   const language = req.i18n_lang;
+  if (config.isDevelopment()) {
+    return res.redirect('/payment-code');
+  }
   if (language === 'en') {
     return res.redirect('https://www.gov.uk/pay-dvsa-roadside-fine');
   }

--- a/src/server/controllers/paymentCode.controller.js
+++ b/src/server/controllers/paymentCode.controller.js
@@ -64,7 +64,8 @@ export const getPaymentDetails = [
       };
       service[getMethod](paymentCode).then((entityData) => {
         const { enabled, location } = entityData;
-        const issueDate = moment(entityData.dateTime || entityData.penaltyGroupDetails.dateTime);
+        const issueDate =
+          moment((entityData.dateTime || entityData.penaltyGroupDetails.dateTime) * 1000);
         const now = moment(new Date());
         const ageDays = moment.duration(now.diff(issueDate)).asDays();
         if (Math.floor(ageDays) > 28) {

--- a/src/server/services/penalty.service.js
+++ b/src/server/services/penalty.service.js
@@ -33,6 +33,7 @@ export default class PenaltyService {
       enabled: data.Enabled,
       paymentCode: rawPenalty.paymentToken,
       issueDate: complete && moment.unix(rawPenalty.dateTime).format('DD/MM/YYYY'),
+      dateTime: rawPenalty.dateTime,
       vehicleReg: complete && rawPenalty.vehicleDetails.regNo,
       formattedReference: rawPenalty.referenceNo,
       location: complete && rawPenalty.placeWhereIssued,

--- a/src/server/services/penaltyGroup.service.js
+++ b/src/server/services/penaltyGroup.service.js
@@ -39,6 +39,7 @@ export default class PenaltyGroupService {
           registrationNumber: VehicleRegistration,
           location: Location,
           date: moment.unix(Timestamp).format('DD/MM/YYYY'),
+          dateTime: Timestamp,
           amount: TotalAmount,
           splitAmounts,
           imPaymentStartTime,


### PR DESCRIPTION
Penalties older than 28 days should not be accessible by the public portal. Redirect to invalid search page when trying to access an invalid penalty.