### PR TITLE
Pull lockout time from env variable

### DIFF
--- a/src/server/i18n/pl.json
+++ b/src/server/i18n/pl.json
@@ -167,7 +167,7 @@
   },
   "payment_pending_page": {
     "title": "Ostrzeżenie",
-    "pending_notice": "Płatność dla tego kodu płatności jest w toku i przycisk jest tymczasowo niedostępny. Należy poczekać do 60 minut na przetworzenie płatności, aby uniknąć podwójnego obciążenia opłatą.",
+    "pending_notice": "Płatność dla tego kodu płatności jest w toku i przycisk jest tymczasowo niedostępny. Należy poczekać do MINUTES minut na przetworzenie płatności, aby uniknąć podwójnego obciążenia opłatą.",
     "go_back": "Wróć",
     "pay_button": "Dalej"
   }


### PR DESCRIPTION
**Description**
Fixes the payment lockout text on the Polish translation which has a hard-coded value of 60 minutes. The change replaces the hard-coded value with a variable which is set in the environment configuration.

**JIRA Ticket**
https://jira.dvsacloud.uk/browse/RSP-1865