### PR TITLE
Rsp 1888 cookie compliance back link fix

### DIFF
--- a/cypress/integration/cookies.spec.js
+++ b/cypress/integration/cookies.spec.js
@@ -54,6 +54,17 @@ context('Cookie Preferences page', () => {
             cy.get('#cookie-preferences-confirmation').should('not.have.class', 'hidden');
         });
 
+        it('has a link which takes me back to the previous page', () => {
+            cy.visit('http://localhost:3000/cookie-details');
+            cy.visit('http://localhost:3000/cookie-preferences');
+            cy.clearCookies();
+            const buttonSavePrefs = cy.contains('Save changes');
+            buttonSavePrefs.click();
+            const backLink = cy.contains('Go back to the page you were looking at');
+            backLink.click();
+            cy.url().should('include', '/cookie-details');
+        });
+
         it('should navigate to the cookie details page', () => {
             cy.contains('Find out more about cookies on Roadside Payments').click();
             cy.url().should('include', '/cookie-details');

--- a/dvsa-frontend-webpack/webpack.config.common.babel.js
+++ b/dvsa-frontend-webpack/webpack.config.common.babel.js
@@ -3,7 +3,8 @@ import path from 'path';
 module.exports = {
   entry: {
     dvsa: path.resolve('src', 'public', 'js', 'dvsa', 'index.js'),
-    cookieManager: path.resolve('src', 'public', 'js', 'cookie-manager.js')
+    cookieManager: path.resolve('src', 'public', 'js', 'cookie-manager.js'),
+    goBack: path.resolve('src', 'public', 'js', 'go-back.js'),
   },
   output: {
     filename: '[name].bundle.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dvsa-rsp-web-public",
-  "version": "1.17.4",
+  "version": "1.17.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvsa-rsp-web-public",
-  "version": "1.17.4",
+  "version": "1.17.5",
   "description": "DVSA Public Payment Portal For RSP",
   "engines": {
     "node": "8.10"

--- a/src/public/js/cookie-manager.js
+++ b/src/public/js/cookie-manager.js
@@ -4,4 +4,3 @@ import * as cookieControl from '../../server/cookie-management/cookie-control';
 
 cookieManager.init(cookieManagerConfig);
 cookieControl.setAnalyticsTracking();
-cookieControl.peferencesConfirmationBack();

--- a/src/public/js/go-back.js
+++ b/src/public/js/go-back.js
@@ -1,0 +1,10 @@
+(() => {
+  const link = document.getElementById('confirmation-go-back');
+
+  if (link !== null) {
+    link.onclick = (event) => {
+      event.preventDefault();
+      window.history.back();
+    };
+  }
+})();

--- a/src/server/cookie-management/cookie-control.js
+++ b/src/server/cookie-management/cookie-control.js
@@ -15,13 +15,3 @@ export const setAnalyticsTracking = () => {
     window['ga-disable-UA-124455500-1'] = false;
   }
 };
-
-export const peferencesConfirmationBack = () => {
-  const link = document.getElementById('confirmation-go-back');
-  if (link !== null) {
-    link.onclick = (event) => {
-      event.preventDefault();
-      window.history.back();
-    };
-  }
-};

--- a/src/server/views/layouts/partials/body-scripts.njk
+++ b/src/server/views/layouts/partials/body-scripts.njk
@@ -5,6 +5,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 
 <script type="text/javascript" src="{{ assets }}/javascripts/dvsa.bundle.js"></script>
+<script type="text/javascript" src="{{ assets }}/javascripts/goBack.bundle.js"></script>
 
 {% block bodyScripts %}{% endblock %}
 <!-- /body-scripts -->


### PR DESCRIPTION
## Description
Implements fix for the back link in the cookie preferences confirmation notification.

JIRA: https://jira.dvsacloud.uk/browse/RSP-1888

## Key changes

- Adds an IIFE for the goBack functionality
- Adds a new bundle loaded in the body to ensure document has loaded
- Bumps app version

![DVSA_RSP_Cookie_Banner](https://user-images.githubusercontent.com/54100299/75145468-ea398780-56f0-11ea-98ad-c7c8bd294636.png)
![DVSA_RSP_Cookie_Details](https://user-images.githubusercontent.com/54100299/75145473-ec034b00-56f0-11ea-9fbe-47e1ee92605c.png)
![DVSA_RSP_Cookie_Preferences](https://user-images.githubusercontent.com/54100299/75145475-ed347800-56f0-11ea-99a7-9fbeeb98af9f.png)
