### PR TITLE
feat: Version pin to v1 of DVSA GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,13 @@ on:
 
 jobs:
   lint:
-    uses: dvsa/.github/.github/workflows/nodejs-lint.yaml@main
+    uses: dvsa/.github/.github/workflows/nodejs-lint.yaml@v1.0.0
 
   test:
-    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@main
+    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v1.0.0
 
   security:
-    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@main
+    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v1.0.0
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
@@ -33,7 +33,7 @@ jobs:
           echo "ARCHIVE_NAME=${PRETTY_BRANCH_NAME}.zip" >> $GITHUB_OUTPUT
 
   build:
-    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@main
+    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v1.0.0
     needs: [ build-names ]
     with:
       upload-artifact: ${{ github.ref_name == 'main' }}
@@ -44,7 +44,7 @@ jobs:
 
   upload-main-to-s3:
     if: startsWith( github.ref, 'refs/heads/feature/') || startsWith( github.ref, 'refs/heads/fix/') || ${{ github.ref_name == github.event.repository.default_branch }}
-    uses: dvsa/.github/.github/workflows/upload-to-s3.yaml@main
+    uses: dvsa/.github/.github/workflows/upload-to-s3.yaml@v1.0.0
     needs: [ lint, test, build, build-names ]
     with:
       environment: dev


### PR DESCRIPTION
## Description

- New version of DVSA workflows will be available soon
- To avoid breaking current CI steps, pin to v1.0.0

Related issue: n/a

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
