### PR TITLE
feat: Remove conditional English language in footer

### DIFF
--- a/src/server/views/layouts/partials/footer.njk
+++ b/src/server/views/layouts/partials/footer.njk
@@ -12,7 +12,7 @@
           <li>{{ t.footer.built_by }}</li>
         </ul>
         <h5 class="visuallyhidden">Languages</h5>
-        <ul>
+        <ul id="translation-list">
           <li>{{ components.link(text='French', url='?clang=fr') }}</li>
           <li>{{ components.link(text='German', url='?clang=de') }}</li>
           <li>{{ components.link(text='Polish', url='?clang=pl') }}</li>

--- a/src/server/views/layouts/partials/footer.njk
+++ b/src/server/views/layouts/partials/footer.njk
@@ -46,7 +46,7 @@
         <div class="version-number">Version 3.1.4</div>
       </div>
 
-      <div class="copyright">
+      <div class="copyright" id="copyright-id">
           <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">&copy; Crown copyright</a>
       </div>
     </div>

--- a/src/server/views/layouts/partials/footer.njk
+++ b/src/server/views/layouts/partials/footer.njk
@@ -13,28 +13,29 @@
         </ul>
         <h5 class="visuallyhidden">Languages</h5>
         <ul>
-          <li>{{ components.link(text='French', url='?clang=fr') if clang != 'fr' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='German', url='?clang=de') if clang != 'de' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Polish', url='?clang=pl') if clang != 'pl' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Spanish', url='?clang=es') if clang != 'es' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Welsh', url='?clang=cy') if clang != 'cy' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Bulgarian', url='?clang=bg') if clang != 'bg' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Croatian', url='?clang=hr') if clang != 'hr' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Czech', url='?clang=cs') if clang != 'cs' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Dutch', url='?clang=nl') if clang != 'nl' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Estonian', url='?clang=et') if clang != 'ee' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Greek', url='?clang=el') if clang != 'el' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Hungarian', url='?clang=hu') if clang != 'hu' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Italian', url='?clang=it') if clang != 'it' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Latvian', url='?clang=lv') if clang != 'lv' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Lithuanian', url='?clang=lt') if clang != 'lt' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Portugeuse', url='?clang=pt') if clang != 'pt' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Romanian', url='?clang=ro') if clang != 'ro' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Russian', url='?clang=ru') if clang != 'ru' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Serbian-Cyrillic', url='?clang=sr') if clang != 'sr' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Slovak', url='?clang=sk') if clang != 'sk' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Slovenian', url='?clang=sl') if clang != 'sl' else components.link(text='English', url='?clang=en') }}</li>
-          <li>{{ components.link(text='Turkish', url='?clang=tr') if clang != 'tr' else components.link(text='English', url='?clang=en') }}</li>
+          <li>{{ components.link(text='French', url='?clang=fr') }}</li>
+          <li>{{ components.link(text='German', url='?clang=de') }}</li>
+          <li>{{ components.link(text='Polish', url='?clang=pl') }}</li>
+          <li>{{ components.link(text='Spanish', url='?clang=es')}}</li>
+          <li>{{ components.link(text='Welsh', url='?clang=cy') }}</li>
+          <li>{{ components.link(text='Bulgarian', url='?clang=bg') }}</li>
+          <li>{{ components.link(text='Croatian', url='?clang=hr') }}</li>
+          <li>{{ components.link(text='Czech', url='?clang=cs') }}</li>
+          <li>{{ components.link(text='Dutch', url='?clang=nl') }}</li>
+          <li>{{ components.link(text='Estonian', url='?clang=et') }}</li>
+          <li>{{ components.link(text='Greek', url='?clang=el') }}</li>
+          <li>{{ components.link(text='Hungarian', url='?clang=hu') }}</li>
+          <li>{{ components.link(text='Italian', url='?clang=it') }}</li>
+          <li>{{ components.link(text='Latvian', url='?clang=lv') }}</li>
+          <li>{{ components.link(text='Lithuanian', url='?clang=lt') }}</li>
+          <li>{{ components.link(text='Portugeuse', url='?clang=pt') }}</li>
+          <li>{{ components.link(text='Romanian', url='?clang=ro') }}</li>
+          <li>{{ components.link(text='Russian', url='?clang=ru') }}</li>
+          <li>{{ components.link(text='Serbian-Cyrillic', url='?clang=sr') }}</li>
+          <li>{{ components.link(text='Slovak', url='?clang=sk') }}</li>
+          <li>{{ components.link(text='Slovenian', url='?clang=sl') }}</li>
+          <li>{{ components.link(text='Turkish', url='?clang=tr') }}</li>
+          <li>{{ components.link(text='English', url='?clang=en') }}</li>
         </ul>
         <div class="open-government-licence">
             <p class="logo">

--- a/src/server/views/layouts/partials/footer.njk
+++ b/src/server/views/layouts/partials/footer.njk
@@ -12,31 +12,7 @@
           <li>{{ t.footer.built_by }}</li>
         </ul>
         <h5 class="visuallyhidden">Languages</h5>
-        <ul id="translation-list" data-testid="translations">
-          <li>{{ components.link(text='French', url='?clang=fr') }}</li>
-          <li>{{ components.link(text='German', url='?clang=de') }}</li>
-          <li>{{ components.link(text='Polish', url='?clang=pl') }}</li>
-          <li>{{ components.link(text='Spanish', url='?clang=es')}}</li>
-          <li>{{ components.link(text='Welsh', url='?clang=cy') }}</li>
-          <li>{{ components.link(text='Bulgarian', url='?clang=bg') }}</li>
-          <li>{{ components.link(text='Croatian', url='?clang=hr') }}</li>
-          <li>{{ components.link(text='Czech', url='?clang=cs') }}</li>
-          <li>{{ components.link(text='Dutch', url='?clang=nl') }}</li>
-          <li>{{ components.link(text='Estonian', url='?clang=et') }}</li>
-          <li>{{ components.link(text='Greek', url='?clang=el') }}</li>
-          <li>{{ components.link(text='Hungarian', url='?clang=hu') }}</li>
-          <li>{{ components.link(text='Italian', url='?clang=it') }}</li>
-          <li>{{ components.link(text='Latvian', url='?clang=lv') }}</li>
-          <li>{{ components.link(text='Lithuanian', url='?clang=lt') }}</li>
-          <li>{{ components.link(text='Portugeuse', url='?clang=pt') }}</li>
-          <li>{{ components.link(text='Romanian', url='?clang=ro') }}</li>
-          <li>{{ components.link(text='Russian', url='?clang=ru') }}</li>
-          <li>{{ components.link(text='Serbian-Cyrillic', url='?clang=sr') }}</li>
-          <li>{{ components.link(text='Slovak', url='?clang=sk') }}</li>
-          <li>{{ components.link(text='Slovenian', url='?clang=sl') }}</li>
-          <li>{{ components.link(text='Turkish', url='?clang=tr') }}</li>
-          <li>{{ components.link(text='English', url='?clang=en') }}</li>
-        </ul>
+          {{ components.translations("translations_footer") }}
         <div class="open-government-licence">
             <p class="logo">
               <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a>

--- a/src/server/views/layouts/partials/footer.njk
+++ b/src/server/views/layouts/partials/footer.njk
@@ -12,7 +12,7 @@
           <li>{{ t.footer.built_by }}</li>
         </ul>
         <h5 class="visuallyhidden">Languages</h5>
-        <ul id="translation-list">
+        <ul id="translation-list" data-testid="translations">
           <li>{{ components.link(text='French', url='?clang=fr') }}</li>
           <li>{{ components.link(text='German', url='?clang=de') }}</li>
           <li>{{ components.link(text='Polish', url='?clang=pl') }}</li>
@@ -46,7 +46,7 @@
         <div class="version-number">Version 3.1.4</div>
       </div>
 
-      <div class="copyright" id="copyright-id">
+      <div class="copyright" id="copyright-id" data-testid="copyright">
           <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">&copy; Crown copyright</a>
       </div>
     </div>

--- a/src/server/views/macros/elements/field.njk
+++ b/src/server/views/macros/elements/field.njk
@@ -23,7 +23,7 @@
     {{ formLabel(label=label, visuallyHidden=labelVisuallyHidden, id=id, bold=labelBold, hint=hint, error=error) }}
     <input 
     {{ 'class="form-control' + ( ' form-control-error' if error ) + ( ' ' + widthClass if widthClass ) + '"' if type !== 'file' }}
-    {{ 'id="' + id + '"' if id }}
+    {{ 'id="' + id + '"' if id }} {{ 'data-testid="' + id + '"' if id }}
     type="{{ type }}"
     name="{{ name if name else id }}"
     value="{{ value }}"

--- a/src/server/views/macros/elements/translations.njk
+++ b/src/server/views/macros/elements/translations.njk
@@ -1,0 +1,29 @@
+{% from "macros/typography/link.njk" import link %}
+
+{% macro translations(id='', class='') %}
+    <ul {{ 'id="' + id + '"' if id }} {{ 'data-testid="' + id + '"' if id }} {{ 'class="' + class + '"' if class }} >
+        <li>{{ link(text='български', url='?clang=bg') }}</li>
+        <li>{{ link(text='Čeština', url='?clang=cs') }}</li>
+        <li>{{ link(text='Српски језик', url='?clang=sr') }}</li>
+        <li>{{ link(text='Cymraeg', url='?clang=cy') }}</li>
+        <li>{{ link(text='Deutsch', url='?clang=de') }}</li>
+        <li>{{ link(text='Ελληνικά', url='?clang=el') }}</li>
+        <li>{{ link(text='Eesti keel', url='?clang=et') }}</li>
+        <li>{{ link(text='Español', url='?clang=es') }}</li>
+        <li>{{ link(text='Français', url='?clang=fr') }}</li>
+        <li>{{ link(text='Hrvatski', url='?clang=hr') }}</li>
+        <li>{{ link(text='Italiano', url='?clang=it') }}</li>
+        <li>{{ link(text='Latviešu', url='?clang=lv') }}</li>
+        <li>{{ link(text='Lietuvių', url='?clang=lt') }}</li>
+        <li>{{ link(text='Magyar', url='?clang=hu') }}</li>
+        <li>{{ link(text='Nederlands', url='?clang=nl') }}</li>
+        <li>{{ link(text='Polski', url='?clang=pl') }}</li>
+        <li>{{ link(text='Português', url='?clang=pt') }}</li>
+        <li>{{ link(text='Ру́сский', url='?clang=ru') }}</li>
+        <li>{{ link(text='Română', url='?clang=ro') }}</li>
+        <li>{{ link(text='Slovenčina', url='?clang=sk') }}</li>
+        <li>{{ link(text='Slovenščina', url='?clang=sl') }}</li>
+        <li>{{ link(text='Türkçe', url='?clang=tr') }}</li>
+        <li>{{ link(text='English', url='?clang=en') }}</li>
+    </ul>
+{% endmacro %}§

--- a/src/server/views/payment/index.njk
+++ b/src/server/views/payment/index.njk
@@ -22,7 +22,7 @@
         {% endif %}
 
         {{ components.heading(text=t.payment_code_page.title, tag='h1', size='xlarge') }}
-        {{ components.field(id='payment_code', label=t.payment_code_page.payment_code, hint=t.payment_code_page.hint, error=t.payment_code_page.error.invalid_code if invalidPaymentCode, maxlength=19) }}
+        {{ components.field(id='payment_code', data-testid="payment_code", label=t.payment_code_page.payment_code, hint=t.payment_code_page.hint, error=t.payment_code_page.error.invalid_code if invalidPaymentCode, maxlength=19) }}
         {% if type === 'overdue' %}
           <ul>
             {% if id %}

--- a/src/server/views/payment/index.njk
+++ b/src/server/views/payment/index.njk
@@ -22,7 +22,7 @@
         {% endif %}
 
         {{ components.heading(text=t.payment_code_page.title, tag='h1', size='xlarge') }}
-        {{ components.field(id='payment_code', data-testid="payment_code", label=t.payment_code_page.payment_code, hint=t.payment_code_page.hint, error=t.payment_code_page.error.invalid_code if invalidPaymentCode, maxlength=19) }}
+        {{ components.field(id='payment_code', label=t.payment_code_page.payment_code, hint=t.payment_code_page.hint, error=t.payment_code_page.error.invalid_code if invalidPaymentCode, maxlength=19) }}
         {% if type === 'overdue' %}
           <ul>
             {% if id %}

--- a/src/server/views/payment/multiPaymentInfo.njk
+++ b/src/server/views/payment/multiPaymentInfo.njk
@@ -49,15 +49,19 @@
             {% set statusClass = 'confirmed' if amountPaid else 'unconfirmed' %}
             {% set showPaymentButton = amount.status == 'UNPAID' %}
             <tr class='no-border'>
-              <td>
                 {% if amount.type == 'FPN' %}
-                  {{ t.penalty_details.type_fixed_penalty }}
+                  <td data-testid="type_fpn">
+                    {{ t.penalty_details.type_fixed_penalty }}
+                  </td>
                 {% elif amount.type == 'CDN' %}
-                  {{ t.penalty_details.type_court_deposit }}
+                  <td data-testid="type_cdn">
+                    {{ t.penalty_details.type_court_deposit }}
+                  <td>
                 {% elif amount.type == 'IM' %}
-                  {{ t.penalty_details.type_immobilisation }}
+                  <td data-testid="type_im">
+                    {{ t.penalty_details.type_immobilisation }}
+                  <td>
                 {% endif %}
-              </td>
               <td>
                 &pound;{{ amount.amount }}
               </td>

--- a/src/server/views/payment/multiPaymentInfo.njk
+++ b/src/server/views/payment/multiPaymentInfo.njk
@@ -171,30 +171,7 @@
     <aside class="govuk-related-items" role="complementary">
         {{ components.heading(text=t.home.language_guidance_header + ':', tag='h3', size='small', id='language-links-header' )}}
         <nav role="navigation" aria-labelledby="language-links-header">
-          <ul class="font-xsmall">
-            <li>{{ components.link(text='български', url='?clang=bg') if clang != 'bg' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Čeština', url='?clang=cs') if clang != 'cs' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Српски језик', url='?clang=sr') if clang != 'sr' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Cymraeg', url='?clang=cy') if clang != 'cy' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Deutsch', url='?clang=de') if clang != 'de' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Ελληνικά', url='?clang=el') if clang != 'el' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Eesti keel', url='?clang=et') if clang != 'et' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Español', url='?clang=es') if clang != 'es' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Français', url='?clang=fr') if clang != 'fr' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Hrvatski', url='?clang=hr') if clang != 'hr' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Italiano', url='?clang=it') if clang != 'it' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Latviešu', url='?clang=lv') if clang != 'lv' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Lietuvių', url='?clang=lt') if clang != 'lt' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Magyar', url='?clang=hu') if clang != 'hu' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Nederlands', url='?clang=nl') if clang != 'nl' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Polski', url='?clang=pl') if clang != 'pl' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Português', url='?clang=pt') if clang != 'pt' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Ру́сский', url='?clang=ru') if clang != 'ru' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Română', url='?clang=ro') if clang != 'ro' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Slovenčina', url='?clang=sk') if clang != 'sk' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Slovenščina', url='?clang=sl') if clang != 'sl' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Türkçe', url='?clang=tr') if clang != 'tr' else components.link(text='English', url='?clang=en') }}</li>
-          </ul>
+          {{ components.translations("translations_side", "font-xsmall") }}
         </nav>
       </aside>
     {%- endcall %}

--- a/src/server/views/payment/paymentDetails.njk
+++ b/src/server/views/payment/paymentDetails.njk
@@ -48,11 +48,11 @@
             </tr>
             <tr>
               {% if type == 'FPN' %}
-                <td>{{ t.penalty_details.type_fixed_penalty }}</td>
+                <td data-testid="type_fpn">{{ t.penalty_details.type_fixed_penalty }}</td>
               {% elif type == 'CDN' %}
-                <td>{{ t.penalty_details.type_court_deposit }}</td>
+                <td data-testid="type_cdn">{{ t.penalty_details.type_court_deposit }}</td>
               {% elif type == 'IM' %}
-                <td>{{ t.penalty_details.type_immobilisation }}</td>
+                <td data-testid="type_im">{{ t.penalty_details.type_immobilisation }}</td>
               {% endif %}
               <td>&pound;{{ amount }}</td>
               <td class="{{ statusClass }}">

--- a/src/server/views/payment/paymentDetails.njk
+++ b/src/server/views/payment/paymentDetails.njk
@@ -156,30 +156,7 @@
       <aside class="govuk-related-items" role="complementary">
         {{ components.heading(text=t.home.language_guidance_header + ':', tag='h3', size='small', id='language-links-header' )}}
         <nav role="navigation" aria-labelledby="language-links-header">
-          <ul class="font-xsmall">
-            <li>{{ components.link(text='български', url='?clang=bg') if clang != 'bg' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Čeština', url='?clang=cs') if clang != 'cs' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Српски језик', url='?clang=sr') if clang != 'sr' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Cymraeg', url='?clang=cy') if clang != 'cy' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Deutsch', url='?clang=de') if clang != 'de' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Ελληνικά', url='?clang=el') if clang != 'el' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Eesti keel', url='?clang=et') if clang != 'et' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Español', url='?clang=es') if clang != 'es' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Français', url='?clang=fr') if clang != 'fr' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Hrvatski', url='?clang=hr') if clang != 'hr' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Italiano', url='?clang=it') if clang != 'it' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Latviešu', url='?clang=lv') if clang != 'lv' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Lietuvių', url='?clang=lt') if clang != 'lt' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Magyar', url='?clang=hu') if clang != 'hu' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Nederlands', url='?clang=nl') if clang != 'nl' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Polski', url='?clang=pl') if clang != 'pl' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Português', url='?clang=pt') if clang != 'pt' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Ру́сский', url='?clang=ru') if clang != 'ru' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Română', url='?clang=ro') if clang != 'ro' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Slovenčina', url='?clang=sk') if clang != 'sk' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Slovenščina', url='?clang=sl') if clang != 'sl' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Türkçe', url='?clang=tr') if clang != 'tr' else components.link(text='English', url='?clang=en') }}</li>
-          </ul>
+          {{ components.translations("translations_side", "font-xsmall") }}
         </nav>
       </aside>
     {%- endcall %}


### PR DESCRIPTION
## Description

- If the user set language is not English the users language link would be replaced with English in the footer
- Removed this conditional check and added English as a list item
- This stops the English link jumping around and being missing from the list when a user changes their language

Related issue: [RSP-1852](https://dvsa.atlassian.net/browse/RSP-1852)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
