### PR TITLE
ci: added release-please action to release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,6 @@ name: Release
 on:
   push:
     branches:
-      - master
 
 env:
   COPY_SOURCE: public-portal/serveExpressApp/master.zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: release-please
     steps:
-      - id: echo zip path
+      - name: echo zip path
         run: |
           echo ${{ env.KEY_PATH }}/release-S{{ needs.release-please.outputs.tag_name }}.zip
           echo ${{ github.event.repository.name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,17 +1,40 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - master
 
 env:
   COPY_SOURCE: public-portal/serveExpressApp/master.zip
   KEY_PATH: public-portal/serveExpressApp
 
 jobs:
-
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      release_created: ${{ steps.release.outputs.release_created }}
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          package-name: rsp-public-portal
+  echo:
+    runs-on: ubuntu-latest
+    needs: release-please
+    steps:
+      id: echo zip path
+      run: |
+        echo ${{ env.KEY_PATH }}/release-S{{ needs.release-please.outputs.tag_name }}.zip
   promote:
     runs-on: ubuntu-latest
+    if: ${{ needs.release-please.outputs.release_created }}
+    needs: release-please
     permissions:
       id-token: write
     steps:
@@ -27,5 +50,5 @@ jobs:
           --tagging-directive REPLACE
           --tagging promote=YES
           --copy-source ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}/${{ env.COPY_SOURCE }}
-          --key ${{ env.KEY_PATH }}/release-${{ github.ref_name }}.zip
+          --key ${{ env.KEY_PATH }}/release-${{ needs.release-please.outputs.tag_name }}.zip
           --bucket ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: echo zip path
         run: |
-          echo ${{ env.KEY_PATH }}/release-S{{ needs.release-please.outputs.tag_name }}.zip
+          echo ${{ env.KEY_PATH }}/release-${{ needs.release-please.outputs.tag_name }}.zip
           echo ${{ github.event.repository.name }}
   promote:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,7 @@ jobs:
       id: echo zip path
       run: |
         echo ${{ env.KEY_PATH }}/release-S{{ needs.release-please.outputs.tag_name }}.zip
+        echo ${{ github.event.repository.name }}
   promote:
     runs-on: ubuntu-latest
     if: ${{ needs.release-please.outputs.release_created }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: release-please
     steps:
-      id: echo zip path
-      run: |
-        echo ${{ env.KEY_PATH }}/release-S{{ needs.release-please.outputs.tag_name }}.zip
-        echo ${{ github.event.repository.name }}
+      - id: echo zip path
+        run: |
+          echo ${{ env.KEY_PATH }}/release-S{{ needs.release-please.outputs.tag_name }}.zip
+          echo ${{ github.event.repository.name }}
   promote:
     runs-on: ubuntu-latest
     if: ${{ needs.release-please.outputs.release_created }}


### PR DESCRIPTION
## Description
- Modified workflow to run on pushes to master branch
- Added job to run release-please action
- Modified promote job to require completion of release-please, and only run when release-please outputs a created release (ie when a release PR is merged)

Related issue: [RSP-2179](https://dvsa.atlassian.net/browse/RSP-2179?atlOrigin=eyJpIjoiNTAyZTUxYzRiY2JjNGIxNTllNTMxYjcwNTVkOTYwMGUiLCJwIjoiaiJ9)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
