### PR TITLE
fix: Fix group payments display page spacing bug

### DIFF
--- a/src/server/views/payment/multiPaymentInfo.njk
+++ b/src/server/views/payment/multiPaymentInfo.njk
@@ -56,11 +56,11 @@
                 {% elif amount.type == 'CDN' %}
                   <td data-testid="type_cdn">
                     {{ t.penalty_details.type_court_deposit }}
-                  <td>
+                  </td>
                 {% elif amount.type == 'IM' %}
                   <td data-testid="type_im">
                     {{ t.penalty_details.type_immobilisation }}
-                  <td>
+                  </td>
                 {% endif %}
               <td>
                 &pound;{{ amount.amount }}


### PR DESCRIPTION
## Description

- Extra spacing on immobilisation penalties causing the row to display incorrectly
- Fixed closing `<td>` elements
- Ticket RSP-2191

Related issue: [RSP-2191](https://dvsa.atlassian.net/browse/RSP-2191)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
