### PR TITLE
ci: Update S3 Key from secret to var

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,6 @@ jobs:
           aws s3api copy-object
           --tagging-directive REPLACE
           --tagging promote=YES
-          --copy-source ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}/${{ secrets.S3_KEY_PATH }}/${{ matrix.lambdaName }}/${{ env.COPY_SOURCE }}
-          --key ${{ secrets.S3_KEY_PATH }}/${{ matrix.lambdaName }}/release-${{ needs.release-please.outputs.tag_name }}.zip
+          --copy-source ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}/${{ vars.S3_KEY_PATH }}/${{ matrix.lambdaName }}/${{ env.COPY_SOURCE }}
+          --key ${{ vars.S3_KEY_PATH }}/${{ matrix.lambdaName }}/release-${{ needs.release-please.outputs.tag_name }}.zip
           --bucket ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}


### PR DESCRIPTION

## Description

- The S3 key path isn't sensitive so can
be set as a repo environment variable
- Easier to see and test if it's a variable

Related issue: [RSP-2227](https://dvsa.atlassian.net/browse/RSP-2227)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?