### PR TITLE
ci: updated workflows to use latest versions, added tagging job for lifecycle policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,13 @@ on:
 
 jobs:
   lint:
-    uses: dvsa/.github/.github/workflows/nodejs-lint.yaml@v1.0.0
+    uses: dvsa/.github/.github/workflows/nodejs-lint.yaml@v3.1.0
 
   test:
-    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v1.0.0
+    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v3.1.0
 
   security:
-    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v1.0.0
+    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v3.1.0
     with:
       args: --all-projects
     secrets:
@@ -37,38 +37,41 @@ jobs:
           echo "ARCHIVE_NAME=${PRETTY_BRANCH_NAME}" >> $GITHUB_OUTPUT
 
   build:
-    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2
+    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v3.1.0
     needs: [ build-names ]
     with:
-      upload_artifact: true
+      upload-artifact: true
 
   upload-s3:
-    if: startsWith( github.ref, 'refs/heads/feature/') || startsWith( github.ref, 'refs/heads/fix/') || ${{ github.ref_name == github.event.repository.default_branch }}
-    uses: dvsa/.github/.github/workflows/upload-to-s3.yaml@v2
+    if: startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/heads/fix/') || startsWith(github.ref, 'refs/heads/master')
+    uses: dvsa/.github/.github/workflows/upload-to-s3.yaml@v3.1.0
     needs: [ lint, test, build, build-names ]
     with:
       environment: nonprod
-      short_commit: ${{  needs.build-names.outputs.short_sha }}
+      short-commit: ${{  needs.build-names.outputs.short_sha }}
       artifact: package.zip
-      bucket_key: public-portal/serveExpressApp/${{ needs.build-names.outputs.archive_name }}.zip
+      bucket-key: public-portal/serveExpressApp/${{ needs.build-names.outputs.archive_name }}.zip
+      optional-tags: lifecycle_subject=${{ startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/heads/fix/') }}
     permissions:
       id-token: write
     secrets:
+      AWS_ROLE_TO_ASSUME_ARN: ${{ secrets.AWS_ROLE_TO_ASSUME_ARN }}
       AWS_ACCOUNT: ${{ secrets.RSP_AWS_ACCOUNT }}
       AWS_REGION: ${{ secrets.RSP_AWS_REGION }}
       BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 
   update-lambda-code:
     if: ${{ github.ref_name == github.event.repository.default_branch }}
-    uses: dvsa/.github/.github/workflows/update-lambda-function.yaml@v2.2
+    uses: dvsa/.github/.github/workflows/update-lambda-function.yaml@v3.1.0
     needs: [ build-names, build, upload-s3 ]
     with:
       environment: nonprod
-      lambda_function_name: rsp-nonprod-apis-public-portal-serveExpressApp
-      bucket_key: public-portal/serveExpressApp/${{ needs.build-names.outputs.archive_name }}.zip
+      lambda-function-name: rsp-nonprod-apis-public-portal-serveExpressApp
+      bucket-key: public-portal/serveExpressApp/${{ needs.build-names.outputs.archive_name }}.zip
     permissions:
       id-token: write
     secrets:
+      AWS_ROLE_TO_ASSUME_ARN: ${{ secrets.AWS_ROLE_TO_ASSUME_ARN }}
       AWS_ACCOUNT: ${{ secrets.RSP_AWS_ACCOUNT }}
       AWS_REGION: ${{ secrets.RSP_AWS_REGION }}
       BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}


### PR DESCRIPTION
## Description

- Updated workflows to use newest version, v3.1.0
- Fixed S3 upload job, so now builds are only uploaded if they are on a branch which starts with either `feat`, `feature`, `fix` or `master`.
- Updated S3 upload job to include an optional lifecycle-subject tag, which is only applied if the branch starts with either `feat`, `feature` or `fix`. Master builds are 
exempt from the policy, so do not need tagging, and other branches will not be uploaded, as they are filtered out by the if statement.
- Added use of `AWS_ROLE_TO_ASSUME` from secrets.
Related issue: [RSP-2091](https://dvsa.atlassian.net/browse/RSP-2091)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>